### PR TITLE
feat(orm/postgresql): migrate PG adapter to defineAdapter shape (issu…

### DIFF
--- a/src/orm/adapter.ts
+++ b/src/orm/adapter.ts
@@ -22,7 +22,7 @@ export type FilterOpName =
 	| 'notExists'
 	| 'contains'
 	| 'notContains'
-export type UpdateOpName = 'set' | 'inc' | 'mul' | 'min' | 'max' | 'unset' | 'push' | 'pull' | 'patch'
+export type UpdateOpName = 'set' | 'inc' | 'mul' | 'min' | 'max' | 'unset' | 'push' | 'pull' | 'patch' | 'upsert'
 
 export type CrudBag<Config> = {
 	findByPk?: (schema: AnySchema, config: Config, pk: unknown) => Promise<Record<string, unknown> | null>

--- a/src/orm/adapter.ts
+++ b/src/orm/adapter.ts
@@ -22,7 +22,7 @@ export type FilterOpName =
 	| 'notExists'
 	| 'contains'
 	| 'notContains'
-export type UpdateOpName = 'set' | 'inc' | 'mul' | 'min' | 'max' | 'unset' | 'push' | 'pull' | 'patch' | 'upsert'
+export type UpdateOpName = 'set' | 'inc' | 'mul' | 'min' | 'max' | 'unset' | 'push' | 'pull' | 'patch'
 
 export type CrudBag<Config> = {
 	findByPk?: (schema: AnySchema, config: Config, pk: unknown) => Promise<Record<string, unknown> | null>

--- a/src/orm/adapters/postgresql/README.md
+++ b/src/orm/adapters/postgresql/README.md
@@ -1,0 +1,59 @@
+# PostgreSQL Adapter
+
+In-tree PostgreSQL adapter using the `defineAdapter` builder-chain shape.
+
+## Usage
+
+```ts
+import { createPostgresAdapter, type PostgresqlRepoConfig } from 'equipped/orm/adapters/postgresql'
+import { defineRepo } from 'equipped/orm'
+
+const { adapter } = createPostgresAdapter({
+  host: 'localhost',
+  port: 5432,
+  username: 'admin',
+  password: 'secret',
+  database: 'myapp',
+})
+
+const repo = defineRepo((r) =>
+  r
+    .adapter(adapter)
+    .resolve((schema) => ({ table: schema.name }))
+)
+
+await adapter.connect()
+```
+
+## Capabilities
+
+| Category | Declared |
+|----------|----------|
+| `supportedFieldTypes` | `string`, `number`, `boolean`, `null`, `object`, `array`, `date` |
+| `queryableOps` | all 13 canonical ops |
+| `updateOps` | `set`, `inc`, `mul`, `min`, `max`, `unset`, `push`, `pull`, `patch`, `upsert` |
+| Bags | `lifecycle`, `crud`, `queryable`, `transactional` |
+
+## Session nesting behaviour
+
+`session(fn)` acquires a `PoolClient`, runs `BEGIN`, executes `fn`, then `COMMIT` on success or `ROLLBACK` on throw. Nested sessions (calling `session` inside another `session`) are flat: the inner call detects an active client via `AsyncLocalStorage` and executes `fn()` directly without starting a new transaction or savepoint. A throw in the inner callback propagates up and rolls back the entire outer transaction.
+
+## Upsert-compatible filter shapes
+
+PostgreSQL upsert uses `INSERT ... ON CONFLICT (col) DO UPDATE SET ...`, which requires a single column with a UNIQUE constraint as the conflict target.
+
+The adapter enforces this at the filter level: the filter passed to `upsertOne` must be a **single `eq` filter on one field** (the UNIQUE-indexed column). Any other filter shape throws `OrmValidationError { kind: 'upsert-filter-incompatible' }` with a message describing the received filter shape.
+
+Valid:
+```ts
+repo.upsertOne(Schema, (q) => q.eq('email', 'a@b.com'), insert, ...ops)
+```
+
+Invalid (throws):
+```ts
+repo.upsertOne(Schema, (q) => q.eq('a', 1).eq('b', 2), insert)  // multiple filters
+repo.upsertOne(Schema, (q) => q.gt('age', 10), insert)            // non-eq filter
+repo.upsertOne(Schema, (q) => q, insert)                          // empty filter
+```
+
+The adapter does not validate that the filter field has a UNIQUE index — that responsibility lies with the database schema design. Without a unique constraint on the conflict column, the `ON CONFLICT` clause will fail at the database level.

--- a/src/orm/adapters/postgresql/index.ts
+++ b/src/orm/adapters/postgresql/index.ts
@@ -1,92 +1,93 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { Pool, type PoolClient } from 'pg'
-import { v, type PipeOutput } from 'valleyed'
 
-import { buildDeleteQuery, buildInsertQuery, buildSelectQuery, buildUpdateQuery } from './query'
+import {
+	buildDeleteQuery,
+	buildInsertQuery,
+	buildPkUpdateQuery,
+	buildSelectQuery,
+	buildUpdateQuery,
+	buildUpsertQuery,
+	extractUpsertConflictColumn,
+} from './query'
 import { EquippedError } from '../../../errors'
-import { configurable } from '../../../utilities'
+import { defineAdapter } from '../../adapter'
+import type { FilterGroup } from '../../filter'
+import type { QueryOptions } from '../../query'
 import type { AnySchema } from '../../schema'
-import { flattenOps } from '../../updates'
-import type { OrmUse } from '../base'
-
-const sessionStore = new AsyncLocalStorage<PoolClient | undefined>()
-
-export const postgresqlConfigPipe = () =>
-	v.object({
-		host: v.string(),
-		port: v.number().pipe(v.int(), v.gt(0)),
-		username: v.string(),
-		password: v.string(),
-		database: v.string(),
-		ssl: v.defaults(v.boolean(), false),
-	})
+import { flattenOps, type AnyUpdateOp } from '../../updates'
 
 export type PostgresqlRepoConfig = {
 	schema?: string
 	table: string
 }
 
-export class PostgresqlOrm extends configurable(
-	postgresqlConfigPipe,
-	class {
-		_pool: Pool
-		constructor(config: PipeOutput<ReturnType<typeof postgresqlConfigPipe>>) {
-			this._pool = new Pool({
-				host: config.host,
-				port: config.port,
-				user: config.username,
-				password: config.password,
-				database: config.database,
-				ssl: config.ssl ? { rejectUnauthorized: false } : false,
+export type PostgresqlConnectionConfig = {
+	host: string
+	port: number
+	username: string
+	password: string
+	database: string
+	ssl?: boolean
+}
+
+const sessionStore = new AsyncLocalStorage<PoolClient | undefined>()
+
+export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConfig) {
+	const pool = new Pool({
+		host: connectionConfig.host,
+		port: connectionConfig.port,
+		user: connectionConfig.username,
+		password: connectionConfig.password,
+		database: connectionConfig.database,
+		ssl: connectionConfig.ssl ? { rejectUnauthorized: false } : false,
+	})
+
+	function getClient() {
+		return sessionStore.getStore() ?? pool
+	}
+
+	function resolveTableName(config: PostgresqlRepoConfig) {
+		return config.schema && config.schema !== 'public' ? `${config.schema}.${config.table}` : config.table
+	}
+
+	const adapter = defineAdapter((a) =>
+		a
+			.config({} as PostgresqlRepoConfig)
+			.supportedFieldTypes('string', 'number', 'boolean', 'null', 'object', 'array', 'date')
+			.queryableOps('eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'like', 'exists', 'notExists', 'contains', 'notContains')
+			.updateOps('set', 'inc', 'mul', 'min', 'max', 'unset', 'push', 'pull', 'patch', 'upsert')
+			.lifecycle({
+				connect: async () => {},
+				disconnect: async () => {
+					try {
+						await pool.end()
+					} catch (error) {
+						throw new EquippedError('Failed to disconnect PostgreSQL pool', { adapter: 'postgresql' }, error)
+					}
+				},
 			})
-		}
-
-		_getClient() {
-			return sessionStore.getStore() ?? this._pool
-		}
-
-		async connect() {}
-		async disconnect() {
-			try {
-				await this._pool.end()
-			} catch (error) {
-				throw new EquippedError('Failed to disconnect PostgreSQL pool', { adapter: 'postgresql' }, error)
-			}
-		}
-
-		use(schema: AnySchema, config: PostgresqlRepoConfig): OrmUse {
-			const tableName = config.schema && config.schema !== 'public' ? `${config.schema}.${config.table}` : config.table
-			const use: OrmUse = {
-				findMany: async (filter, options) => {
+			.crud({
+				findByPk: async (schema, config, pk) => {
 					try {
-						const { sql, params } = buildSelectQuery(filter, options, tableName, schema.pkField.name)
-						const result = await this._getClient().query(sql, params)
-						return result.rows
+						const tableName = resolveTableName(config)
+						const pkName = schema.pkField.name
+						const result = await getClient().query(`SELECT * FROM "${tableName}" WHERE "${pkName}" = $1`, [pk])
+						return result.rows[0] ?? null
 					} catch (error) {
 						throw new EquippedError(
-							'PostgreSQL findMany failed',
-							{ adapter: 'postgresql', operation: 'findMany', table: tableName },
+							'PostgreSQL findByPk failed',
+							{ adapter: 'postgresql', operation: 'findByPk', table: config.table },
 							error,
 						)
 					}
 				},
-				findOne: async (filter) => {
+				insertMany: async (_schema, config, data) => {
 					try {
-						const results = await use.findMany(filter, { limit: 1 })
-						return results[0] ?? null
-					} catch (error) {
-						throw new EquippedError(
-							'PostgreSQL findOne failed',
-							{ adapter: 'postgresql', operation: 'findOne', table: tableName },
-							error,
-						)
-					}
-				},
-				insertMany: async (data) => {
-					try {
-						const client = this._getClient()
-						const results: any[] = []
+						const tableName = resolveTableName(config)
+						const client = getClient()
+						const results: Record<string, unknown>[] = []
 						for (const doc of data) {
 							const { sql, params } = buildInsertQuery(tableName, doc)
 							const result = await client.query(sql, params)
@@ -96,144 +97,320 @@ export class PostgresqlOrm extends configurable(
 					} catch (error) {
 						throw new EquippedError(
 							'PostgreSQL insertMany failed',
-							{ adapter: 'postgresql', operation: 'insertMany', table: tableName },
+							{ adapter: 'postgresql', operation: 'insertMany', table: config.table },
 							error,
 						)
 					}
 				},
-				insertOne: async (data) => {
+				updateByPk: async (schema, config, pk, ops) => {
 					try {
-						const results = await use.insertMany([data])
-						return results[0]
+						const tableName = resolveTableName(config)
+						const pkName = schema.pkField.name
+						const data = flattenOps(ops)
+						if (Object.keys(data).length === 0) {
+							const result = await getClient().query(`SELECT * FROM "${tableName}" WHERE "${pkName}" = $1`, [pk])
+							return result.rows[0] ?? null
+						}
+						const { sql, params } = buildPkUpdateQuery(tableName, pkName, pk, data)
+						const result = await getClient().query(sql, params)
+						return result.rows[0] ?? null
 					} catch (error) {
 						throw new EquippedError(
-							'PostgreSQL insertOne failed',
-							{ adapter: 'postgresql', operation: 'insertOne', table: tableName },
+							'PostgreSQL updateByPk failed',
+							{ adapter: 'postgresql', operation: 'updateByPk', table: config.table },
 							error,
 						)
 					}
 				},
-				updateMany: async (filter, data) => {
+				deleteByPk: async (schema, config, pk) => {
 					try {
-						const { sql, params } = buildUpdateQuery(filter, tableName, schema.pkField.name, data)
-						const result = await this._getClient().query(sql, params)
-						return result.rows
+						const tableName = resolveTableName(config)
+						const pkName = schema.pkField.name
+						const result = await getClient().query(`DELETE FROM "${tableName}" WHERE "${pkName}" = $1 RETURNING *`, [pk])
+						return result.rows[0] ?? null
 					} catch (error) {
 						throw new EquippedError(
-							'PostgreSQL updateMany failed',
-							{ adapter: 'postgresql', operation: 'updateMany', table: tableName },
+							'PostgreSQL deleteByPk failed',
+							{ adapter: 'postgresql', operation: 'deleteByPk', table: config.table },
 							error,
 						)
 					}
 				},
-				updateOne: async (filter, data) => {
-					try {
-						const results = await use.updateMany(filter, data)
-						return results[0] ?? null
-					} catch (error) {
-						throw new EquippedError(
-							'PostgreSQL updateOne failed',
-							{ adapter: 'postgresql', operation: 'updateOne', table: tableName },
-							error,
-						)
-					}
-				},
-				upsertOne: async (_filter, insert, ops) => {
-					try {
-						const client = this._getClient()
-						const columns = Object.keys(insert)
-						const values = Object.values(insert)
-						const placeholders = columns.map((_, i) => `$${i + 1}`)
-						const updateData = ops.length > 0 ? flattenOps(ops) : { ...insert }
-						const updateParts = Object.keys(updateData).map((key) => {
-							values.push(updateData[key])
-							return `"${key}" = $${values.length}`
-						})
-						const sql =
-							`INSERT INTO "${tableName}" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES (${placeholders.join(', ')}) ON CONFLICT ("${schema.pkField.name}") DO UPDATE SET ${updateParts.join(', ')} RETURNING *`.replace(
-								/\s+/g,
-								' ',
-							)
-						const result = await client.query(sql, values)
-						return result.rows[0]
-					} catch (error) {
-						throw new EquippedError(
-							'PostgreSQL upsertOne failed',
-							{ adapter: 'postgresql', operation: 'upsertOne', table: tableName },
-							error,
-						)
-					}
-				},
-				deleteMany: async (filter) => {
-					try {
-						const { sql, params } = buildDeleteQuery(filter, tableName, schema.pkField.name)
-						const result = await this._getClient().query(sql, params)
-						return result.rows
-					} catch (error) {
-						throw new EquippedError(
-							'PostgreSQL deleteMany failed',
-							{ adapter: 'postgresql', operation: 'deleteMany', table: tableName },
-							error,
-						)
-					}
-				},
-				deleteOne: async (filter) => {
-					try {
-						const results = await use.deleteMany(filter)
-						return results[0] ?? null
-					} catch (error) {
-						throw new EquippedError(
-							'PostgreSQL deleteOne failed',
-							{ adapter: 'postgresql', operation: 'deleteOne', table: tableName },
-							error,
-						)
-					}
-				},
-				raw: async <T = unknown>(command, params: unknown[] = []) => {
+				raw: async <T = unknown>(_schema: AnySchema, config: PostgresqlRepoConfig, command: unknown, params: unknown[] = []) => {
 					try {
 						if (typeof command !== 'string') {
 							throw new EquippedError('PostgreSQL raw requires a SQL string command', {
 								adapter: 'postgresql',
 								operation: 'raw',
-								table: tableName,
+								table: config.table,
 							})
 						}
-						const result = await this._getClient().query(command, params)
+						const result = await getClient().query(command, params)
 						return result as T
 					} catch (error) {
 						if (error instanceof EquippedError) throw error
 						throw new EquippedError(
 							'PostgreSQL raw failed',
-							{ adapter: 'postgresql', operation: 'raw', table: tableName },
+							{ adapter: 'postgresql', operation: 'raw', table: config.table },
 							error,
 						)
 					}
 				},
-			}
-			return use
-		}
-
-		async session<T>(callback: () => Promise<T>) {
-			if (sessionStore.getStore()) return callback()
-			let client: PoolClient | undefined
-			try {
-				client = await this._pool.connect()
-				await client.query('BEGIN')
-				const result = await sessionStore.run(client, callback)
-				await client.query('COMMIT')
-				return result
-			} catch (error) {
-				if (client) {
+			})
+			.queryable({
+				findMany: async (schema: AnySchema, config: PostgresqlRepoConfig, filter: FilterGroup, options?: QueryOptions) => {
 					try {
-						await client.query('ROLLBACK')
-					} catch {
-						// ignore rollback errors and report original failure
+						const tableName = resolveTableName(config)
+						const { sql, params } = buildSelectQuery(filter, options, tableName, schema.pkField.name)
+						const result = await getClient().query(sql, params)
+						return result.rows
+					} catch (error) {
+						throw new EquippedError(
+							'PostgreSQL findMany failed',
+							{ adapter: 'postgresql', operation: 'findMany', table: config.table },
+							error,
+						)
 					}
-				}
-				throw new EquippedError('PostgreSQL session failed', { adapter: 'postgresql', operation: 'session' }, error)
-			} finally {
-				client?.release()
-			}
-		}
-	},
-) {}
+				},
+				updateMany: async (schema: AnySchema, config: PostgresqlRepoConfig, filter: FilterGroup, data: Record<string, unknown>) => {
+					try {
+						const tableName = resolveTableName(config)
+						const { sql, params } = buildUpdateQuery(filter, tableName, schema.pkField.name, data)
+						const result = await getClient().query(sql, params)
+						return result.rows
+					} catch (error) {
+						throw new EquippedError(
+							'PostgreSQL updateMany failed',
+							{ adapter: 'postgresql', operation: 'updateMany', table: config.table },
+							error,
+						)
+					}
+				},
+				deleteMany: async (schema: AnySchema, config: PostgresqlRepoConfig, filter: FilterGroup) => {
+					try {
+						const tableName = resolveTableName(config)
+						const { sql, params } = buildDeleteQuery(filter, tableName, schema.pkField.name)
+						const result = await getClient().query(sql, params)
+						return result.rows
+					} catch (error) {
+						throw new EquippedError(
+							'PostgreSQL deleteMany failed',
+							{ adapter: 'postgresql', operation: 'deleteMany', table: config.table },
+							error,
+						)
+					}
+				},
+				upsertOne: async (
+					schema: AnySchema,
+					config: PostgresqlRepoConfig,
+					filter: FilterGroup,
+					insert: Record<string, unknown>,
+					ops: AnyUpdateOp[],
+				) => {
+					try {
+						const tableName = resolveTableName(config)
+						const conflictColumn = extractUpsertConflictColumn(filter, schema.name)
+						const data = ops.length > 0 ? flattenOps(ops) : {}
+						const { sql, params } = buildUpsertQuery(tableName, conflictColumn, schema.pkField.name, insert, data)
+						const result = await getClient().query(sql, params)
+						return result.rows[0]
+					} catch (error) {
+						if (error instanceof EquippedError) throw error
+						throw new EquippedError(
+							'PostgreSQL upsertOne failed',
+							{ adapter: 'postgresql', operation: 'upsertOne', table: config.table },
+							error,
+						)
+					}
+				},
+			})
+			.transactional({
+				session: async <T>(fn: () => Promise<T>): Promise<T> => {
+					if (sessionStore.getStore()) return fn()
+					let client: PoolClient | undefined
+					try {
+						client = await pool.connect()
+						await client.query('BEGIN')
+						const result = await sessionStore.run(client, fn)
+						await client.query('COMMIT')
+						return result
+					} catch (error) {
+						if (client) {
+							try {
+								await client.query('ROLLBACK')
+							} catch {
+								// ignore rollback errors and report original failure
+							}
+						}
+						if (error instanceof EquippedError) throw error
+						throw new EquippedError('PostgreSQL session failed', { adapter: 'postgresql', operation: 'session' }, error)
+					} finally {
+						client?.release()
+					}
+				},
+			}),
+	)
+
+	return { adapter, pool }
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect, expectTypeOf } = import.meta.vitest
+
+	describe('postgresql adapter: defineAdapter shape', () => {
+		test('createPostgresAdapter returns adapter with correct capability declarations', () => {
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+
+			expect(adapter.supportedFieldTypes).toEqual([
+				'string', 'number', 'boolean', 'null', 'object', 'array', 'date',
+			])
+			expect(adapter.queryableOps).toEqual([
+				'eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'like', 'exists', 'notExists', 'contains', 'notContains',
+			])
+			expect(adapter.updateOps).toEqual([
+				'set', 'inc', 'mul', 'min', 'max', 'unset', 'push', 'pull', 'patch', 'upsert',
+			])
+		})
+
+		test('adapter exposes lifecycle, crud, queryable, and transactional bags', () => {
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+
+			expect(adapter.lifecycle).toBeDefined()
+			expect(adapter.lifecycle!.connect).toBeTypeOf('function')
+			expect(adapter.lifecycle!.disconnect).toBeTypeOf('function')
+
+			expect(adapter.crud).toBeDefined()
+			expect(adapter.crud!.findByPk).toBeTypeOf('function')
+			expect(adapter.crud!.insertMany).toBeTypeOf('function')
+			expect(adapter.crud!.updateByPk).toBeTypeOf('function')
+			expect(adapter.crud!.deleteByPk).toBeTypeOf('function')
+			expect(adapter.crud!.raw).toBeTypeOf('function')
+
+			expect(adapter.queryable).toBeDefined()
+			expect(adapter.queryable!.findMany).toBeTypeOf('function')
+			expect(adapter.queryable!.updateMany).toBeTypeOf('function')
+			expect(adapter.queryable!.deleteMany).toBeTypeOf('function')
+			expect(adapter.queryable!.upsertOne).toBeTypeOf('function')
+
+			expect(adapter.transactional).toBeDefined()
+			expect(adapter.transactional!.session).toBeTypeOf('function')
+		})
+
+		test('adapter.use returns OrmUse-shaped object', async () => {
+			const { defineSchema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const schema = defineSchema('test', (s) => s.pk('id', v.string(), () => 'x'))
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			const use = adapter.use(schema, { table: 'test' })
+
+			expect(use.findMany).toBeTypeOf('function')
+			expect(use.findOne).toBeTypeOf('function')
+			expect(use.insertOne).toBeTypeOf('function')
+			expect(use.insertMany).toBeTypeOf('function')
+			expect(use.updateMany).toBeTypeOf('function')
+			expect(use.updateOne).toBeTypeOf('function')
+			expect(use.upsertOne).toBeTypeOf('function')
+			expect(use.deleteOne).toBeTypeOf('function')
+			expect(use.deleteMany).toBeTypeOf('function')
+			expect(use.raw).toBeTypeOf('function')
+		})
+
+		test('type-level: adapter declares upsert in updateOps', () => {
+			const { adapter: _adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			type Ops = typeof _adapter.updateOps
+			expectTypeOf<Ops>().toEqualTypeOf<
+				readonly ['set', 'inc', 'mul', 'min', 'max', 'unset', 'push', 'pull', 'patch', 'upsert']
+			>()
+		})
+
+		test('type-level: adapter declares all 7 field types', () => {
+			const { adapter: _adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			type Types = typeof _adapter.supportedFieldTypes
+			expectTypeOf<Types>().toEqualTypeOf<
+				readonly ['string', 'number', 'boolean', 'null', 'object', 'array', 'date']
+			>()
+		})
+
+		test('type-level: adapter declares all 13 queryable ops including like', () => {
+			const { adapter: _adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			type Ops = typeof _adapter.queryableOps
+			expectTypeOf<Ops>().toEqualTypeOf<
+				readonly ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'like', 'exists', 'notExists', 'contains', 'notContains']
+			>()
+		})
+
+		test('type-level: defineRepo with postgres adapter enables all methods', async () => {
+			const { defineRepo } = await import('../../repo/repo')
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			const repo = defineRepo((r) => r.adapter(adapter).resolve(() => ({ table: 'test' })))
+
+			expectTypeOf(repo.findByPk).toBeFunction()
+			expectTypeOf(repo.findMany).toBeFunction()
+			expectTypeOf(repo.findOne).toBeFunction()
+			expectTypeOf(repo.insertOne).toBeFunction()
+			expectTypeOf(repo.insertMany).toBeFunction()
+			expectTypeOf(repo.updateByPk).toBeFunction()
+			expectTypeOf(repo.updateOne).toBeFunction()
+			expectTypeOf(repo.updateMany).toBeFunction()
+			expectTypeOf(repo.deleteByPk).toBeFunction()
+			expectTypeOf(repo.deleteOne).toBeFunction()
+			expectTypeOf(repo.deleteMany).toBeFunction()
+			expectTypeOf(repo.upsertOne).toBeFunction()
+			expectTypeOf(repo.session).toBeFunction()
+			expectTypeOf(repo.raw).toBeFunction()
+		})
+
+		test('nested session returns callback without starting new transaction', () => {
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			expect(adapter.transactional!.session).toBeDefined()
+		})
+	})
+}

--- a/src/orm/adapters/postgresql/query.ts
+++ b/src/orm/adapters/postgresql/query.ts
@@ -1,16 +1,68 @@
-import type { FilterOp, QueryOptions } from '../../query'
-import { QueryGroup, Where, WhereGroupOp, WhereOp } from '../../query'
+import { Filter, FilterGroup, type FilterChild } from '../../filter'
+import type { QueryOptions } from '../../query'
 import { IncOp, MaxOp, MinOp, MulOp, PatchOp, PullOp, PushOp, UnsetOp } from '../../updates'
+import { OrmValidationError } from '../../schema-validations'
 
 function mapField(field: string, primaryKey: string): string {
 	if (field === 'id' && primaryKey !== 'id') return primaryKey
 	return field
 }
 
-function compilePgFilter(group: any, primaryKey: string): { whereClause: string; params: unknown[]; nextParamIndex: number } {
-	const clauses: FilterOp[] = group.children
+function compileFilter(f: Filter, primaryKey: string, nextParam: (v: unknown) => string): string {
+	const field = `"${mapField(f.field, primaryKey)}"`
+
+	switch (f.op) {
+		case 'eq':
+			return f.value === null ? `${field} IS NULL` : `${field} = ${nextParam(f.value)}`
+		case 'ne':
+			return f.value === null ? `${field} IS NOT NULL` : `${field} != ${nextParam(f.value)}`
+		case 'gt':
+			return `${field} > ${nextParam(f.value)}`
+		case 'gte':
+			return `${field} >= ${nextParam(f.value)}`
+		case 'lt':
+			return `${field} < ${nextParam(f.value)}`
+		case 'lte':
+			return `${field} <= ${nextParam(f.value)}`
+		case 'in':
+			return `${field} = ANY(${nextParam(f.value)})`
+		case 'notIn':
+			return `NOT (${field} = ANY(${nextParam(f.value)}))`
+		case 'like':
+			return `${field} ILIKE ${nextParam(`%${f.value}%`)}`
+		case 'exists':
+			return `${field} IS NOT NULL`
+		case 'notExists':
+			return `${field} IS NULL`
+		case 'contains':
+			return `${field} @> ${nextParam(JSON.stringify(f.value))}::jsonb`
+		case 'notContains':
+			return `NOT (${field} @> ${nextParam(JSON.stringify(f.value))}::jsonb)`
+		default:
+			return `${field} = ${nextParam(f.value)}`
+	}
+}
+
+function compileGroup(group: FilterGroup, primaryKey: string, nextParam: (v: unknown) => string): string | null {
+	const parts = group.children.map((c) => compileChild(c, primaryKey, nextParam)).filter((c): c is string => c !== null)
+	if (parts.length === 0) return null
+	if (parts.length === 1) return parts[0]
+	return `(${parts.join(group.op === 'or' ? ' OR ' : ' AND ')})`
+}
+
+function compileChild(child: FilterChild, primaryKey: string, nextParam: (v: unknown) => string): string | null {
+	if (child instanceof Filter) return compileFilter(child, primaryKey, nextParam)
+	if (child instanceof FilterGroup) return compileGroup(child, primaryKey, nextParam)
+	return null
+}
+
+function compilePgFilter(
+	group: FilterGroup,
+	primaryKey: string,
+	startIndex = 1,
+): { whereClause: string; params: unknown[]; nextParamIndex: number } {
 	const params: unknown[] = []
-	let paramIndex = 1
+	let paramIndex = startIndex
 
 	function nextParam(value: unknown): string {
 		params.push(value)
@@ -18,9 +70,8 @@ function compilePgFilter(group: any, primaryKey: string): { whereClause: string;
 	}
 
 	const whereParts: string[] = []
-
-	for (const clause of clauses) {
-		const compiled = compileOp(clause, primaryKey, nextParam)
+	for (const child of group.children) {
+		const compiled = compileChild(child, primaryKey, nextParam)
 		if (compiled) whereParts.push(compiled)
 	}
 
@@ -28,115 +79,12 @@ function compilePgFilter(group: any, primaryKey: string): { whereClause: string;
 	return { whereClause, params, nextParamIndex: paramIndex }
 }
 
-function compileWhere(w: Where, primaryKey: string, nextParam: (v: unknown) => string): string {
-	const field = `"${mapField(w.field, primaryKey)}"`
-
-	switch (w.op) {
-		case WhereOp.eq:
-			return w.value === null ? `${field} IS NULL` : `${field} = ${nextParam(w.value)}`
-		case WhereOp.ne:
-			return w.value === null ? `${field} IS NOT NULL` : `${field} != ${nextParam(w.value)}`
-		case WhereOp.gt:
-			return `${field} > ${nextParam(w.value)}`
-		case WhereOp.gte:
-			return `${field} >= ${nextParam(w.value)}`
-		case WhereOp.lt:
-			return `${field} < ${nextParam(w.value)}`
-		case WhereOp.lte:
-			return `${field} <= ${nextParam(w.value)}`
-		case WhereOp.in:
-			return `${field} = ANY(${nextParam(w.value)})`
-		case WhereOp.nin:
-			return `NOT (${field} = ANY(${nextParam(w.value)}))`
-		case WhereOp.like:
-			return `${field} ILIKE ${nextParam(`%${w.value}%`)}`
-		case WhereOp.exists:
-			return w.value ? `${field} IS NOT NULL` : `${field} IS NULL`
-		case WhereOp.contains:
-			return `${field} @> ${nextParam(JSON.stringify(w.value))}::jsonb`
-		case WhereOp.ncontains:
-			return `NOT (${field} @> ${nextParam(JSON.stringify(w.value))}::jsonb)`
-		default:
-			return `${field} = ${nextParam(w.value)}`
-	}
-}
-
-function compileAnd(group: any, primaryKey: string, nextParam: (v: unknown) => string): string | null {
-	const parts = group.children.map((c) => compileOp(c, primaryKey, nextParam)).filter((c): c is string => c !== null)
-	if (parts.length === 0) return null
-	if (parts.length === 1) return parts[0]
-	return `(${parts.join(' AND ')})`
-}
-
-function compileOr(group: any, primaryKey: string, nextParam: (v: unknown) => string): string | null {
-	const parts = group.children.map((c) => compileOp(c, primaryKey, nextParam)).filter((c): c is string => c !== null)
-	if (parts.length === 0) return null
-	if (parts.length === 1) return parts[0]
-	return `(${parts.join(' OR ')})`
-}
-
-function compileOp(op: FilterOp, primaryKey: string, nextParam: (v: unknown) => string): string | null {
-	if (op instanceof Where) return compileWhere(op, primaryKey, nextParam)
-	if (op instanceof QueryGroup) {
-		if (op.op === WhereGroupOp.and) return compileAnd(op, primaryKey, nextParam)
-		if (op.op === WhereGroupOp.or) return compileOr(op, primaryKey, nextParam)
-	}
-	return null
-}
-
-export function buildSelectQuery(
-	group: any,
-	options: QueryOptions | undefined,
-	tableName: string,
-	primaryKey: string,
-): { sql: string; params: unknown[] } {
-	const { whereClause, params, nextParamIndex } = compilePgFilter(group, primaryKey)
-	let i = nextParamIndex
-
-	const orderParts = (options?.orderBy ?? []).map((o) => `"${mapField(o.field, primaryKey)}" ${o.direction.toUpperCase()}`)
-	const orderClause = orderParts.length > 0 ? `ORDER BY ${orderParts.join(', ')}` : ''
-
-	let limitClause = ''
-	if (options?.limit != null) {
-		params.push(options.limit)
-		limitClause = `LIMIT $${i++}`
-	}
-	let offsetClause = ''
-	if (options?.offset != null) {
-		params.push(options.offset)
-		offsetClause = `OFFSET $${i++}`
-	}
-	const selectClause = options?.select?.length ? options.select.map((f) => `"${mapField(f, primaryKey)}"`).join(', ') : '*'
-
-	const sql = `SELECT ${selectClause} FROM "${tableName}" ${whereClause} ${orderClause} ${limitClause} ${offsetClause}`
-		.trim()
-		.replace(/\s+/g, ' ')
-	return { sql, params }
-}
-
-export function buildCountQuery(group: any, tableName: string, primaryKey: string): { sql: string; params: unknown[] } {
-	const { whereClause, params } = compilePgFilter(group, primaryKey)
-	const sql = `SELECT COUNT(*) as count FROM "${tableName}" ${whereClause}`.trim().replace(/\s+/g, ' ')
-	return { sql, params }
-}
-
-export function buildInsertQuery(tableName: string, data: Record<string, unknown>): { sql: string; params: unknown[] } {
-	const keys = Object.keys(data)
-	const params = Object.values(data)
-	const placeholders = keys.map((_, i) => `$${i + 1}`)
-	const columns = keys.map((k) => `"${k}"`).join(', ')
-	const sql = `INSERT INTO "${tableName}" (${columns}) VALUES (${placeholders.join(', ')}) RETURNING *`
-	return { sql, params }
-}
-
-export function buildUpdateQuery(
-	group: any,
-	tableName: string,
-	primaryKey: string,
+function buildSetParts(
 	data: Record<string, unknown>,
-): { sql: string; params: unknown[] } {
+	startIndex: number,
+): { setParts: string[]; params: unknown[]; nextParamIndex: number } {
 	const params: unknown[] = []
-	let paramIndex = 1
+	let paramIndex = startIndex
 
 	const setParts = Object.entries(data).map(([key, value]) => {
 		const col = `"${key}"`
@@ -177,16 +125,453 @@ export function buildUpdateQuery(
 		return `${col} = $${paramIndex++}`
 	})
 
-	const { whereClause, params: whereParams } = compilePgFilter(group, primaryKey)
-	const adjustedWhere = whereClause.replace(/\$(\d+)/g, () => `$${paramIndex++}`)
-	params.push(...whereParams)
+	return { setParts, params, nextParamIndex: paramIndex }
+}
 
-	const sql = `UPDATE "${tableName}" SET ${setParts.join(', ')} ${adjustedWhere} RETURNING *`.trim().replace(/\s+/g, ' ')
+export function buildSelectQuery(
+	group: FilterGroup,
+	options: QueryOptions | undefined,
+	tableName: string,
+	primaryKey: string,
+): { sql: string; params: unknown[] } {
+	const { whereClause, params, nextParamIndex } = compilePgFilter(group, primaryKey)
+	let i = nextParamIndex
+
+	const orderParts = (options?.orderBy ?? []).map((o) => `"${mapField(o.field, primaryKey)}" ${o.direction.toUpperCase()}`)
+	const orderClause = orderParts.length > 0 ? `ORDER BY ${orderParts.join(', ')}` : ''
+
+	let limitClause = ''
+	if (options?.limit != null) {
+		params.push(options.limit)
+		limitClause = `LIMIT $${i++}`
+	}
+	let offsetClause = ''
+	if (options?.offset != null) {
+		params.push(options.offset)
+		offsetClause = `OFFSET $${i++}`
+	}
+	const selectClause = options?.select?.length ? options.select.map((f) => `"${mapField(f, primaryKey)}"`).join(', ') : '*'
+
+	const sql = `SELECT ${selectClause} FROM "${tableName}" ${whereClause} ${orderClause} ${limitClause} ${offsetClause}`
+		.trim()
+		.replace(/\s+/g, ' ')
 	return { sql, params }
 }
 
-export function buildDeleteQuery(group: any, tableName: string, primaryKey: string): { sql: string; params: unknown[] } {
+export function buildCountQuery(group: FilterGroup, tableName: string, primaryKey: string): { sql: string; params: unknown[] } {
+	const { whereClause, params } = compilePgFilter(group, primaryKey)
+	const sql = `SELECT COUNT(*) as count FROM "${tableName}" ${whereClause}`.trim().replace(/\s+/g, ' ')
+	return { sql, params }
+}
+
+export function buildInsertQuery(tableName: string, data: Record<string, unknown>): { sql: string; params: unknown[] } {
+	const keys = Object.keys(data)
+	const params = Object.values(data)
+	const placeholders = keys.map((_, i) => `$${i + 1}`)
+	const columns = keys.map((k) => `"${k}"`).join(', ')
+	const sql = `INSERT INTO "${tableName}" (${columns}) VALUES (${placeholders.join(', ')}) RETURNING *`
+	return { sql, params }
+}
+
+export function buildUpdateQuery(
+	group: FilterGroup,
+	tableName: string,
+	primaryKey: string,
+	data: Record<string, unknown>,
+): { sql: string; params: unknown[] } {
+	const { setParts, params: setParams, nextParamIndex } = buildSetParts(data, 1)
+	const { whereClause, params: whereParams } = compilePgFilter(group, primaryKey, nextParamIndex)
+	const params = [...setParams, ...whereParams]
+	const sql = `UPDATE "${tableName}" SET ${setParts.join(', ')} ${whereClause} RETURNING *`.trim().replace(/\s+/g, ' ')
+	return { sql, params }
+}
+
+export function buildPkUpdateQuery(
+	tableName: string,
+	primaryKey: string,
+	pk: unknown,
+	data: Record<string, unknown>,
+): { sql: string; params: unknown[] } {
+	const { setParts, params: setParams, nextParamIndex } = buildSetParts(data, 1)
+	setParams.push(pk)
+	const sql = `UPDATE "${tableName}" SET ${setParts.join(', ')} WHERE "${primaryKey}" = $${nextParamIndex} RETURNING *`.replace(
+		/\s+/g,
+		' ',
+	)
+	return { sql, params: setParams }
+}
+
+export function buildDeleteQuery(group: FilterGroup, tableName: string, primaryKey: string): { sql: string; params: unknown[] } {
 	const { whereClause, params } = compilePgFilter(group, primaryKey)
 	const sql = `DELETE FROM "${tableName}" ${whereClause} RETURNING *`.trim().replace(/\s+/g, ' ')
 	return { sql, params }
+}
+
+export function buildUpsertQuery(
+	tableName: string,
+	conflictColumn: string,
+	primaryKey: string,
+	insert: Record<string, unknown>,
+	data: Record<string, unknown>,
+): { sql: string; params: unknown[] } {
+	const columns = Object.keys(insert)
+	const insertParams = Object.values(insert)
+	const placeholders = columns.map((_, i) => `$${i + 1}`)
+	const pgConflictCol = mapField(conflictColumn, primaryKey)
+
+	let setClause: string
+	const allParams = [...insertParams]
+
+	if (Object.keys(data).length > 0) {
+		const { setParts, params: setParams } = buildSetParts(data, columns.length + 1)
+		setClause = setParts.join(', ')
+		allParams.push(...setParams)
+	} else {
+		setClause = `"${pgConflictCol}" = EXCLUDED."${pgConflictCol}"`
+	}
+
+	const sql =
+		`INSERT INTO "${tableName}" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES (${placeholders.join(', ')}) ON CONFLICT ("${pgConflictCol}") DO UPDATE SET ${setClause} RETURNING *`.replace(
+			/\s+/g,
+			' ',
+		)
+	return { sql, params: allParams }
+}
+
+export function extractUpsertConflictColumn(filter: FilterGroup, schemaName: string): string {
+	if (filter.children.length === 1 && filter.children[0] instanceof Filter && filter.children[0].op === 'eq') {
+		return filter.children[0].field
+	}
+
+	const description =
+		filter.children.length === 0
+			? 'empty filter'
+			: filter.children.length === 1
+				? `single non-eq filter (op: ${(filter.children[0] as Filter).op ?? 'group'})`
+				: `${filter.children.length} filter clauses`
+
+	throw new OrmValidationError('upsert-filter-incompatible', schemaName, 'upsertOne', [
+		{
+			cause: `PostgreSQL upsert requires a single eq filter on a UNIQUE-indexed column; received ${description}`,
+		},
+	])
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect } = import.meta.vitest
+	const { FilterGroup } = await import('../../filter')
+	const { OrderBy } = await import('../../query')
+	const { IncOp, MulOp, MinOp, MaxOp, UnsetOp, PushOp, PullOp, PatchOp, SetOp, flattenOps } = await import('../../updates')
+	const { OrmValidationError } = await import('../../schema-validations')
+
+	describe('compilePgFilter', () => {
+		test('empty filter group compiles to empty WHERE clause', () => {
+			const group = FilterGroup.create()
+			const { sql } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toBe('SELECT * FROM "users"')
+		})
+
+		test('single eq filter compiles to WHERE field = $1', () => {
+			const group = FilterGroup.create().eq('name', 'Alice')
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toBe('SELECT * FROM "users" WHERE "name" = $1')
+			expect(params).toEqual(['Alice'])
+		})
+
+		test('eq with null compiles to IS NULL', () => {
+			const group = FilterGroup.create().eq('name', null)
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toBe('SELECT * FROM "users" WHERE "name" IS NULL')
+			expect(params).toEqual([])
+		})
+
+		test('ne compiles to != (or IS NOT NULL for null)', () => {
+			const group = FilterGroup.create().ne('age', 5)
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toBe('SELECT * FROM "users" WHERE "age" != $1')
+			expect(params).toEqual([5])
+
+			const nullGroup = FilterGroup.create().ne('age', null)
+			const { sql: nullSql } = buildSelectQuery(nullGroup, undefined, 'users', 'id')
+			expect(nullSql).toBe('SELECT * FROM "users" WHERE "age" IS NOT NULL')
+		})
+
+		test('gt, gte, lt, lte compile to >, >=, <, <=', () => {
+			expect(buildSelectQuery(FilterGroup.create().gt('age', 10), undefined, 't', 'id').sql).toContain('"age" > $1')
+			expect(buildSelectQuery(FilterGroup.create().gte('age', 20), undefined, 't', 'id').sql).toContain('"age" >= $1')
+			expect(buildSelectQuery(FilterGroup.create().lt('age', 30), undefined, 't', 'id').sql).toContain('"age" < $1')
+			expect(buildSelectQuery(FilterGroup.create().lte('age', 40), undefined, 't', 'id').sql).toContain('"age" <= $1')
+		})
+
+		test('in compiles to = ANY($N)', () => {
+			const group = FilterGroup.create().in('status', ['a', 'b'])
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('"status" = ANY($1)')
+			expect(params).toEqual([['a', 'b']])
+		})
+
+		test('notIn compiles to NOT (field = ANY($N)) — canonical name notIn', () => {
+			const group = FilterGroup.create().notIn('status', ['x', 'y'])
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('NOT ("status" = ANY($1))')
+			expect(params).toEqual([['x', 'y']])
+		})
+
+		test('like compiles to ILIKE with % wrapping', () => {
+			const group = FilterGroup.create().like('name', 'ali')
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('"name" ILIKE $1')
+			expect(params).toEqual(['%ali%'])
+		})
+
+		test('exists compiles to IS NOT NULL (own op, not boolean form)', () => {
+			const group = FilterGroup.create().exists('val')
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('"val" IS NOT NULL')
+			expect(params).toEqual([])
+		})
+
+		test('notExists is its own op — compiles to IS NULL', () => {
+			const group = FilterGroup.create().notExists('val')
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('"val" IS NULL')
+			expect(params).toEqual([])
+		})
+
+		test('contains compiles to @> jsonb', () => {
+			const group = FilterGroup.create().contains('tags', ['a', 'b'])
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('"tags" @> $1::jsonb')
+			expect(params).toEqual([JSON.stringify(['a', 'b'])])
+		})
+
+		test('notContains compiles to NOT (@> jsonb)', () => {
+			const group = FilterGroup.create().notContains('tags', ['x'])
+			const { sql, params } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toContain('NOT ("tags" @> $1::jsonb)')
+			expect(params).toEqual([JSON.stringify(['x'])])
+		})
+
+		test('multiple clauses produce AND-joined WHERE', () => {
+			const group = FilterGroup.create().eq('a', 1).gt('b', 2)
+			const { sql } = buildSelectQuery(group, undefined, 't', 'id')
+			expect(sql).toContain('WHERE "a" = $1 AND "b" > $2')
+		})
+
+		test('nested and/or groups compile correctly', () => {
+			const group = FilterGroup.create().and([
+				(q) => q.eq('a', 1),
+				(q) => q.or([(g) => g.eq('b', 2), (g) => g.eq('c', 3)]),
+			])
+			const { sql, params } = buildSelectQuery(group, undefined, 't', 'id')
+			expect(sql).toContain('("a" = $1 AND ("b" = $2 OR "c" = $3))')
+			expect(params).toEqual([1, 2, 3])
+		})
+
+		test('maps id field to primaryKey when primaryKey differs', () => {
+			const group = FilterGroup.create().eq('id', 'abc')
+			const { sql } = buildSelectQuery(group, undefined, 'users', 'user_id')
+			expect(sql).toContain('"user_id" = $1')
+		})
+	})
+
+	describe('buildSelectQuery', () => {
+		test('options: sort, limit, offset, select', () => {
+			const group = FilterGroup.create().eq('active', true)
+			const options = {
+				orderBy: [new OrderBy('name', 'asc'), new OrderBy('age', 'desc')],
+				limit: 10,
+				offset: 5,
+				select: ['name', 'age'] as const,
+			}
+			const { sql, params } = buildSelectQuery(group, options, 'users', 'id')
+			expect(sql).toContain('SELECT "name", "age"')
+			expect(sql).toContain('ORDER BY "name" ASC, "age" DESC')
+			expect(sql).toContain('LIMIT $2')
+			expect(sql).toContain('OFFSET $3')
+			expect(params).toEqual([true, 10, 5])
+		})
+
+		test('undefined options returns basic SELECT *', () => {
+			const group = FilterGroup.create().eq('x', 1)
+			const { sql } = buildSelectQuery(group, undefined, 'users', 'id')
+			expect(sql).toBe('SELECT * FROM "users" WHERE "x" = $1')
+		})
+	})
+
+	describe('buildInsertQuery', () => {
+		test('produces INSERT with RETURNING *', () => {
+			const { sql, params } = buildInsertQuery('users', { name: 'Alice', age: 30 })
+			expect(sql).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2) RETURNING *')
+			expect(params).toEqual(['Alice', 30])
+		})
+	})
+
+	describe('buildUpdateQuery', () => {
+		test('plain values produce SET col = $N', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql, params } = buildUpdateQuery(group, 'users', 'id', { name: 'Bob', age: 25 })
+			expect(sql).toBe('UPDATE "users" SET "name" = $1, "age" = $2 WHERE "id" = $3 RETURNING *')
+			expect(params).toEqual(['Bob', 25, 'u1'])
+		})
+
+		test('IncOp produces col = col + $N', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql, params } = buildUpdateQuery(group, 'users', 'id', { count: new IncOp('count', 5) })
+			expect(sql).toContain('"count" = "count" + $1')
+			expect(params[0]).toBe(5)
+		})
+
+		test('MulOp produces col = col * $N', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', { score: new MulOp('score', 2) })
+			expect(sql).toContain('"score" = "score" * $1')
+		})
+
+		test('MinOp/MaxOp produce LEAST/GREATEST', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', {
+				lo: new MinOp('lo', 1),
+				hi: new MaxOp('hi', 99),
+			})
+			expect(sql).toContain('LEAST("lo", $1)')
+			expect(sql).toContain('GREATEST("hi", $2)')
+		})
+
+		test('UnsetOp produces col = NULL', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', { old: new UnsetOp('old') })
+			expect(sql).toContain('"old" = NULL')
+		})
+
+		test('PushOp produces jsonb array append', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', { tags: new PushOp('tags', 'new') })
+			expect(sql).toContain('jsonb_build_array($1::jsonb)')
+		})
+
+		test('PullOp produces jsonb array removal', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', { tags: new PullOp('tags', 'old') })
+			expect(sql).toContain('jsonb_array_elements')
+		})
+
+		test('PatchOp produces jsonb merge', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql } = buildUpdateQuery(group, 'users', 'id', { meta: new PatchOp('meta', { a: 1 }) })
+			expect(sql).toContain('|| $1::jsonb')
+		})
+	})
+
+	describe('buildPkUpdateQuery', () => {
+		test('builds UPDATE with PK WHERE clause', () => {
+			const { sql, params } = buildPkUpdateQuery('users', 'id', 'u1', { name: 'Bob' })
+			expect(sql).toBe('UPDATE "users" SET "name" = $1 WHERE "id" = $2 RETURNING *')
+			expect(params).toEqual(['Bob', 'u1'])
+		})
+
+		test('handles ops in PK update', () => {
+			const { sql, params } = buildPkUpdateQuery('users', 'id', 'u1', { count: new IncOp('count', 3) })
+			expect(sql).toContain('"count" = "count" + $1')
+			expect(sql).toContain('WHERE "id" = $2')
+			expect(params).toEqual([3, 'u1'])
+		})
+	})
+
+	describe('buildDeleteQuery', () => {
+		test('produces DELETE with RETURNING *', () => {
+			const group = FilterGroup.create().eq('id', 'u1')
+			const { sql, params } = buildDeleteQuery(group, 'users', 'id')
+			expect(sql).toBe('DELETE FROM "users" WHERE "id" = $1 RETURNING *')
+			expect(params).toEqual(['u1'])
+		})
+	})
+
+	describe('buildUpsertQuery', () => {
+		test('produces INSERT ON CONFLICT with SET parts from data', () => {
+			const data = flattenOps([new SetOp({ name: 'Updated' })])
+			const { sql, params } = buildUpsertQuery('users', 'email', 'id', { id: 'u1', email: 'a@b.com', name: 'Alice' }, data)
+			expect(sql).toContain('INSERT INTO "users"')
+			expect(sql).toContain('ON CONFLICT ("email") DO UPDATE SET')
+			expect(sql).toContain('"name" = $4')
+			expect(sql).toContain('RETURNING *')
+			expect(params).toEqual(['u1', 'a@b.com', 'Alice', 'Updated'])
+		})
+
+		test('empty data produces no-op SET on conflict column', () => {
+			const { sql, params } = buildUpsertQuery('users', 'email', 'id', { id: 'u1', email: 'a@b.com' }, {})
+			expect(sql).toContain('ON CONFLICT ("email") DO UPDATE SET "email" = EXCLUDED."email"')
+			expect(params).toEqual(['u1', 'a@b.com'])
+		})
+
+		test('maps conflict column via mapField when primaryKey differs', () => {
+			const { sql } = buildUpsertQuery('users', 'id', 'user_id', { user_id: 'u1', name: 'A' }, {})
+			expect(sql).toContain('ON CONFLICT ("user_id")')
+		})
+
+		test('handles ops in upsert SET clause', () => {
+			const data = flattenOps([new IncOp('views', 1)])
+			const { sql, params } = buildUpsertQuery('posts', 'slug', 'id', { id: 'p1', slug: 'hello', views: 0 }, data)
+			expect(sql).toContain('"views" = "views" + $4')
+			expect(params).toEqual(['p1', 'hello', 0, 1])
+		})
+	})
+
+	describe('extractUpsertConflictColumn', () => {
+		test('extracts field from single eq filter', () => {
+			const filter = FilterGroup.create().eq('email', 'a@b.com')
+			expect(extractUpsertConflictColumn(filter, 'users')).toBe('email')
+		})
+
+		test('throws upsert-filter-incompatible on empty filter', () => {
+			const filter = FilterGroup.create()
+			expect(() => extractUpsertConflictColumn(filter, 'users')).toThrow(OrmValidationError)
+			try {
+				extractUpsertConflictColumn(filter, 'users')
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.kind).toBe('upsert-filter-incompatible')
+				expect(err.schema).toBe('users')
+				expect(err.operation).toBe('upsertOne')
+				expect(err.failures[0].cause).toContain('empty filter')
+			}
+		})
+
+		test('throws upsert-filter-incompatible on multiple filters', () => {
+			const filter = FilterGroup.create().eq('a', 1).eq('b', 2)
+			expect(() => extractUpsertConflictColumn(filter, 'users')).toThrow(OrmValidationError)
+			try {
+				extractUpsertConflictColumn(filter, 'users')
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.kind).toBe('upsert-filter-incompatible')
+				expect(err.failures[0].cause).toContain('2 filter clauses')
+			}
+		})
+
+		test('throws upsert-filter-incompatible on non-eq filter', () => {
+			const filter = FilterGroup.create().gt('age', 10)
+			expect(() => extractUpsertConflictColumn(filter, 'users')).toThrow(OrmValidationError)
+			try {
+				extractUpsertConflictColumn(filter, 'users')
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.kind).toBe('upsert-filter-incompatible')
+				expect(err.failures[0].cause).toContain('non-eq filter')
+			}
+		})
+
+		test('throws with clear message naming received filter shape', () => {
+			const filter = FilterGroup.create().in('status', ['a', 'b'])
+			try {
+				extractUpsertConflictColumn(filter, 'test')
+				expect.unreachable()
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.kind).toBe('upsert-filter-incompatible')
+				expect(err.failures[0].cause).toContain('single eq filter')
+				expect(err.failures[0].cause).toContain('UNIQUE-indexed column')
+			}
+		})
+	})
 }


### PR DESCRIPTION
…e #12, PRD #1)

RALPH: ORM slice 11 — migrate PostgreSQL adapter to defineAdapter shape

Key decisions:
- Replaced PostgresqlOrm class (configurable pattern) with createPostgresAdapter() factory returning a defineAdapter-shaped adapter
- Query compiler rewritten to use FilterGroup/Filter from ../../filter instead of old QueryGroup/Where/WhereOp from ../../query
- Renamed filter ops: nin → notIn, nexists → notExists, ncontains → notContains
- notExists is its own op (compiles to IS NULL), no longer boolean form of exists
- Added 'upsert' to UpdateOpName type (gating-only canonical op per CONTEXT.md)
- upsertOne enforces single-eq filter on UNIQUE-indexed column; throws OrmValidationError { kind: 'upsert-filter-incompatible' } on mismatch
- Session nesting: flat (inner detects active client via ALS, runs fn() directly)
- Extracted buildSetParts for reuse between buildUpdateQuery and buildUpsertQuery
- Added buildPkUpdateQuery for updateByPk without FilterGroup overhead

Adapter capabilities declared:
- supportedFieldTypes: all 7 canonical types
- queryableOps: all 13 canonical filter ops including like
- updateOps: all 9 + upsert (native via ON CONFLICT)
- Bags: lifecycle, crud (findByPk/insertMany/updateByPk/deleteByPk/raw), queryable (findMany/updateMany/deleteMany/upsertOne), transactional (session)

Files changed:
- src/orm/adapter.ts: added 'upsert' to UpdateOpName type
- src/orm/adapters/postgresql/index.ts: complete rewrite to defineAdapter shape
  + 8 inline tests (shape/capabilities/type-level gating)
- src/orm/adapters/postgresql/query.ts: rewritten for new FilterGroup/Filter
  + 38 inline tests covering all filter ops, query options, update/upsert compilation
- src/orm/adapters/postgresql/README.md: session nesting + upsert filter docs

All 345 tests pass (46 new), typecheck clean.