### PR TITLE
Sandcastle: ORM: rename insert → create across the codebase (#29)

### DIFF
--- a/src/orm/adapter.ts
+++ b/src/orm/adapter.ts
@@ -26,7 +26,7 @@ export type UpdateOpName = 'set' | 'inc' | 'mul' | 'min' | 'max' | 'unset' | 'pu
 
 export type CrudBag<Config> = {
 	findByPk?: (schema: AnySchema, config: Config, pk: unknown) => Promise<Record<string, unknown> | null>
-	insertMany?: (schema: AnySchema, config: Config, data: Record<string, unknown>[]) => Promise<Record<string, unknown>[]>
+	createMany?: (schema: AnySchema, config: Config, data: Record<string, unknown>[]) => Promise<Record<string, unknown>[]>
 	updateByPk?: (
 		schema: AnySchema,
 		config: Config,
@@ -55,7 +55,7 @@ export type QueryableBag<Config> = {
 		schema: AnySchema,
 		config: Config,
 		filter: FilterGroup,
-		insert: Record<string, unknown>,
+		create: Record<string, unknown>,
 		ops: AnyUpdateOp[],
 	) => Promise<Record<string, unknown>>
 }
@@ -180,19 +180,19 @@ export function defineAdapter<Acc>(build: (b: AdapterBuilder) => AdapterBuilder<
 				const rows = await use.findMany(filter, { limit: 1 })
 				return rows[0] ?? null
 			},
-			insertOne: async (d) => {
-				const rows = await use.insertMany([d])
+			createOne: async (d) => {
+				const rows = await use.createMany([d])
 				return rows[0]
 			},
-			insertMany: (d) => crud?.insertMany?.(schema, config, d) ?? Promise.resolve([]),
+			createMany: (d) => crud?.createMany?.(schema, config, d) ?? Promise.resolve([]),
 			updateMany: (filter, d) =>
 				queryable?.updateMany?.(schema, config, filter, d) ?? Promise.resolve([]),
 			updateOne: async (filter, d) => {
 				const rows = await use.updateMany(filter, d)
 				return rows[0] ?? null
 			},
-			upsertOne: (filter, insert, ops) =>
-				queryable?.upsertOne?.(schema, config, filter, insert, ops) ?? Promise.reject(new Error('upsertOne not implemented')),
+			upsertOne: (filter, create, ops) =>
+				queryable?.upsertOne?.(schema, config, filter, create, ops) ?? Promise.reject(new Error('upsertOne not implemented')),
 			deleteOne: async (filter) => {
 				const row = await use.findOne(filter)
 				if (!row) return null

--- a/src/orm/adapters/base.ts
+++ b/src/orm/adapters/base.ts
@@ -6,13 +6,13 @@ import type { AnyUpdateOp } from '../updates'
 export type OrmUse = {
 	findMany: (filter: FilterGroup, options?: QueryOptions) => Promise<Record<string, unknown>[]>
 	findOne: (filter: FilterGroup) => Promise<Record<string, unknown> | null>
-	insertOne: (data: Record<string, unknown>) => Promise<Record<string, unknown>>
-	insertMany: (data: Record<string, unknown>[]) => Promise<Record<string, unknown>[]>
+	createOne: (data: Record<string, unknown>) => Promise<Record<string, unknown>>
+	createMany: (data: Record<string, unknown>[]) => Promise<Record<string, unknown>[]>
 	updateMany: (filter: FilterGroup, data: Record<string, unknown>) => Promise<Record<string, unknown>[]>
 	updateOne: (filter: FilterGroup, data: Record<string, unknown>) => Promise<Record<string, unknown> | null>
 	upsertOne: (
 		filter: FilterGroup,
-		insert: Record<string, unknown>,
+		create: Record<string, unknown>,
 		ops: AnyUpdateOp[],
 	) => Promise<Record<string, unknown>>
 	deleteOne: (filter: FilterGroup) => Promise<Record<string, unknown> | null>

--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -258,7 +258,7 @@ export function createInMemoryAdapter() {
 					const doc = store.get(String(pk))
 					return doc ? clone(doc) : null
 				},
-				insertMany: async (schema, config, data) => {
+				createMany: async (schema, config, data) => {
 					const pk = schema.pkField.name
 					const store = getStore(resolveConfigName(schema, config))
 					return data.map((d) => {
@@ -318,7 +318,7 @@ export function createInMemoryAdapter() {
 					for (const row of rows) store.delete(String(row[pk]))
 					return rows
 				},
-				upsertOne: async (schema, config, filter, insert, ops) => {
+				upsertOne: async (schema, config, filter, create, ops) => {
 					const store = getStore(resolveConfigName(schema, config))
 					const pk = schema.pkField.name
 					const rows = [...store.values()].filter((doc) => matchesFilter(doc, filter))
@@ -328,7 +328,7 @@ export function createInMemoryAdapter() {
 						store.set(String(next[pk]), next)
 						return clone(next)
 					}
-					const base = clone(insert)
+					const base = clone(create)
 					const result = ops.length > 0 ? applyOps(base, ops) : base
 					store.set(String(result[pk]), result)
 					return clone(result)
@@ -370,7 +370,7 @@ if (import.meta.vitest) {
 			)
 			const { adapter } = createInMemoryAdapter()
 			const use = adapter.use(schema, { table: 'users' })
-			await use.insertMany([
+			await use.createMany([
 				{ id: 'u1', name: 'Alice', age: 30 },
 				{ id: 'u2', name: 'Bob', age: 20 },
 				{ id: 'u3', name: 'Carol', age: 40 },
@@ -394,7 +394,7 @@ if (import.meta.vitest) {
 			)
 			const { adapter } = createInMemoryAdapter()
 			const use = adapter.use(schema, { table: 'docs' })
-			await use.insertOne({ id: 'd1', count: 1, tags: ['x'], meta: { a: 1 } })
+			await use.createOne({ id: 'd1', count: 1, tags: ['x'], meta: { a: 1 } })
 
 			await adapter.session(async () => {
 				await use.updateOne(FilterGroup.create().eq('id', 'd1'), {
@@ -421,7 +421,7 @@ if (import.meta.vitest) {
 			)
 			const { adapter } = createInMemoryAdapter()
 			const use = adapter.use(schema, { table: 'users' })
-			await use.insertMany([
+			await use.createMany([
 				{ id: 'u1', name: 'Alice' },
 				{ id: 'u2', name: 'Bob' },
 				{ id: 'u3', name: 'Carol' },
@@ -437,7 +437,7 @@ if (import.meta.vitest) {
 			)
 			const { adapter } = createInMemoryAdapter()
 			const use = adapter.use(schema, { table: 'items' })
-			await use.insertMany([
+			await use.createMany([
 				{ id: 'i1', val: 'present' },
 				{ id: 'i2', val: null },
 				{ id: 'i3', val: undefined },
@@ -455,7 +455,7 @@ if (import.meta.vitest) {
 			const { adapter } = createInMemoryAdapter()
 
 			const use = adapter.use(schema, { prefix: 'test' })
-			await use.insertOne({ id: 'x' })
+			await use.createOne({ id: 'x' })
 
 			const found = await adapter.crud.findByPk!(schema, { prefix: 'test' }, 'x')
 			expect(found).toEqual({ id: 'x' })

--- a/src/orm/adapters/mongodb/index.ts
+++ b/src/orm/adapters/mongodb/index.ts
@@ -83,7 +83,7 @@ export function createMongoAdapter(connectionConfig: MongoDbConnectionConfig) {
 						)
 					}
 				},
-				insertMany: async (_schema, config, data) => {
+				createMany: async (_schema, config, data) => {
 					try {
 						const collection = getCollection(config)
 						const docs = data.map((d) => d as OptionalUnlessRequiredId<any>)
@@ -91,8 +91,8 @@ export function createMongoAdapter(connectionConfig: MongoDbConnectionConfig) {
 						return data
 					} catch (error) {
 						throw new EquippedError(
-							'MongoDB insertMany failed',
-							{ adapter: 'mongodb', operation: 'insertMany', collection: config.col },
+							'MongoDB createMany failed',
+							{ adapter: 'mongodb', operation: 'createMany', collection: config.col },
 							error,
 						)
 					}
@@ -225,7 +225,7 @@ export function createMongoAdapter(connectionConfig: MongoDbConnectionConfig) {
 						)
 					}
 				},
-				upsertOne: async (schema: AnySchema, config: MongoDbRepoConfig, filter: FilterGroup, insert: Record<string, unknown>, ops: AnyUpdateOp[]) => {
+				upsertOne: async (schema: AnySchema, config: MongoDbRepoConfig, filter: FilterGroup, create: Record<string, unknown>, ops: AnyUpdateOp[]) => {
 					try {
 						const pk = schema.pkField.name
 						const collection = getCollection(config)
@@ -236,7 +236,7 @@ export function createMongoAdapter(connectionConfig: MongoDbConnectionConfig) {
 							mongoFilter,
 							{
 								...updateDoc,
-								$setOnInsert: insert,
+								$setOnInsert: create,
 							},
 							{
 								returnDocument: 'after',
@@ -303,7 +303,7 @@ if (import.meta.vitest) {
 
 			expect(adapter.crud).toBeDefined()
 			expect(adapter.crud!.findByPk).toBeTypeOf('function')
-			expect(adapter.crud!.insertMany).toBeTypeOf('function')
+			expect(adapter.crud!.createMany).toBeTypeOf('function')
 			expect(adapter.crud!.updateByPk).toBeTypeOf('function')
 			expect(adapter.crud!.deleteByPk).toBeTypeOf('function')
 			expect(adapter.crud!.raw).toBeTypeOf('function')
@@ -327,8 +327,8 @@ if (import.meta.vitest) {
 
 			expect(use.findMany).toBeTypeOf('function')
 			expect(use.findOne).toBeTypeOf('function')
-			expect(use.insertOne).toBeTypeOf('function')
-			expect(use.insertMany).toBeTypeOf('function')
+			expect(use.createOne).toBeTypeOf('function')
+			expect(use.createMany).toBeTypeOf('function')
 			expect(use.updateMany).toBeTypeOf('function')
 			expect(use.updateOne).toBeTypeOf('function')
 			expect(use.upsertOne).toBeTypeOf('function')
@@ -369,8 +369,8 @@ if (import.meta.vitest) {
 			expectTypeOf(repo.findByPk).toBeFunction()
 			expectTypeOf(repo.findMany).toBeFunction()
 			expectTypeOf(repo.findOne).toBeFunction()
-			expectTypeOf(repo.insertOne).toBeFunction()
-			expectTypeOf(repo.insertMany).toBeFunction()
+			expectTypeOf(repo.createOne).toBeFunction()
+			expectTypeOf(repo.createMany).toBeFunction()
 			expectTypeOf(repo.updateByPk).toBeFunction()
 			expectTypeOf(repo.updateOne).toBeFunction()
 			expectTypeOf(repo.updateMany).toBeFunction()

--- a/src/orm/adapters/postgresql/README.md
+++ b/src/orm/adapters/postgresql/README.md
@@ -46,14 +46,14 @@ The adapter enforces this at the filter level: the filter passed to `upsertOne` 
 
 Valid:
 ```ts
-repo.upsertOne(Schema, (q) => q.eq('email', 'a@b.com'), insert, ...ops)
+repo.upsertOne(Schema, (q) => q.eq('email', 'a@b.com'), create, ...ops)
 ```
 
 Invalid (throws):
 ```ts
-repo.upsertOne(Schema, (q) => q.eq('a', 1).eq('b', 2), insert)  // multiple filters
-repo.upsertOne(Schema, (q) => q.gt('age', 10), insert)            // non-eq filter
-repo.upsertOne(Schema, (q) => q, insert)                          // empty filter
+repo.upsertOne(Schema, (q) => q.eq('a', 1).eq('b', 2), create)  // multiple filters
+repo.upsertOne(Schema, (q) => q.gt('age', 10), create)            // non-eq filter
+repo.upsertOne(Schema, (q) => q, create)                          // empty filter
 ```
 
 The adapter does not validate that the filter field has a UNIQUE index — that responsibility lies with the database schema design. Without a unique constraint on the conflict column, the `ON CONFLICT` clause will fail at the database level.

--- a/src/orm/adapters/postgresql/index.ts
+++ b/src/orm/adapters/postgresql/index.ts
@@ -4,7 +4,7 @@ import { Pool, type PoolClient } from 'pg'
 
 import {
 	buildDeleteQuery,
-	buildInsertQuery,
+	buildCreateQuery,
 	buildPkUpdateQuery,
 	buildSelectQuery,
 	buildUpdateQuery,
@@ -89,7 +89,7 @@ export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConf
 						const client = getClient()
 						const results: Record<string, unknown>[] = []
 						for (const doc of data) {
-							const { sql, params } = buildInsertQuery(tableName, doc)
+							const { sql, params } = buildCreateQuery(tableName, doc)
 							const result = await client.query(sql, params)
 							results.push(result.rows[0])
 						}

--- a/src/orm/adapters/postgresql/index.ts
+++ b/src/orm/adapters/postgresql/index.ts
@@ -83,7 +83,7 @@ export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConf
 						)
 					}
 				},
-				insertMany: async (_schema, config, data) => {
+				createMany: async (_schema, config, data) => {
 					try {
 						const tableName = resolveTableName(config)
 						const client = getClient()
@@ -96,8 +96,8 @@ export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConf
 						return results
 					} catch (error) {
 						throw new EquippedError(
-							'PostgreSQL insertMany failed',
-							{ adapter: 'postgresql', operation: 'insertMany', table: config.table },
+							'PostgreSQL createMany failed',
+							{ adapter: 'postgresql', operation: 'createMany', table: config.table },
 							error,
 						)
 					}
@@ -204,14 +204,14 @@ export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConf
 					schema: AnySchema,
 					config: PostgresqlRepoConfig,
 					filter: FilterGroup,
-					insert: Record<string, unknown>,
+					create: Record<string, unknown>,
 					ops: AnyUpdateOp[],
 				) => {
 					try {
 						const tableName = resolveTableName(config)
 						const conflictColumn = extractUpsertConflictColumn(filter, schema.name)
 						const data = ops.length > 0 ? flattenOps(ops) : {}
-						const { sql, params } = buildUpsertQuery(tableName, conflictColumn, schema.pkField.name, insert, data)
+						const { sql, params } = buildUpsertQuery(tableName, conflictColumn, schema.pkField.name, create, data)
 						const result = await getClient().query(sql, params)
 						return result.rows[0]
 					} catch (error) {
@@ -293,7 +293,7 @@ if (import.meta.vitest) {
 
 			expect(adapter.crud).toBeDefined()
 			expect(adapter.crud!.findByPk).toBeTypeOf('function')
-			expect(adapter.crud!.insertMany).toBeTypeOf('function')
+			expect(adapter.crud!.createMany).toBeTypeOf('function')
 			expect(adapter.crud!.updateByPk).toBeTypeOf('function')
 			expect(adapter.crud!.deleteByPk).toBeTypeOf('function')
 			expect(adapter.crud!.raw).toBeTypeOf('function')
@@ -323,8 +323,8 @@ if (import.meta.vitest) {
 
 			expect(use.findMany).toBeTypeOf('function')
 			expect(use.findOne).toBeTypeOf('function')
-			expect(use.insertOne).toBeTypeOf('function')
-			expect(use.insertMany).toBeTypeOf('function')
+			expect(use.createOne).toBeTypeOf('function')
+			expect(use.createMany).toBeTypeOf('function')
 			expect(use.updateMany).toBeTypeOf('function')
 			expect(use.updateOne).toBeTypeOf('function')
 			expect(use.upsertOne).toBeTypeOf('function')
@@ -389,8 +389,8 @@ if (import.meta.vitest) {
 			expectTypeOf(repo.findByPk).toBeFunction()
 			expectTypeOf(repo.findMany).toBeFunction()
 			expectTypeOf(repo.findOne).toBeFunction()
-			expectTypeOf(repo.insertOne).toBeFunction()
-			expectTypeOf(repo.insertMany).toBeFunction()
+			expectTypeOf(repo.createOne).toBeFunction()
+			expectTypeOf(repo.createMany).toBeFunction()
 			expectTypeOf(repo.updateByPk).toBeFunction()
 			expectTypeOf(repo.updateOne).toBeFunction()
 			expectTypeOf(repo.updateMany).toBeFunction()

--- a/src/orm/adapters/postgresql/query.ts
+++ b/src/orm/adapters/postgresql/query.ts
@@ -211,16 +211,16 @@ export function buildUpsertQuery(
 	tableName: string,
 	conflictColumn: string,
 	primaryKey: string,
-	insert: Record<string, unknown>,
+	create: Record<string, unknown>,
 	data: Record<string, unknown>,
 ): { sql: string; params: unknown[] } {
-	const columns = Object.keys(insert)
-	const insertParams = Object.values(insert)
+	const columns = Object.keys(create)
+	const createParams = Object.values(create)
 	const placeholders = columns.map((_, i) => `$${i + 1}`)
 	const pgConflictCol = mapField(conflictColumn, primaryKey)
 
 	let setClause: string
-	const allParams = [...insertParams]
+	const allParams = [...createParams]
 
 	if (Object.keys(data).length > 0) {
 		const { setParts, params: setParams } = buildSetParts(data, columns.length + 1)

--- a/src/orm/adapters/postgresql/query.ts
+++ b/src/orm/adapters/postgresql/query.ts
@@ -164,7 +164,7 @@ export function buildCountQuery(group: FilterGroup, tableName: string, primaryKe
 	return { sql, params }
 }
 
-export function buildInsertQuery(tableName: string, data: Record<string, unknown>): { sql: string; params: unknown[] } {
+export function buildCreateQuery(tableName: string, data: Record<string, unknown>): { sql: string; params: unknown[] } {
 	const keys = Object.keys(data)
 	const params = Object.values(data)
 	const placeholders = keys.map((_, i) => `$${i + 1}`)
@@ -403,9 +403,9 @@ if (import.meta.vitest) {
 		})
 	})
 
-	describe('buildInsertQuery', () => {
+	describe('buildCreateQuery', () => {
 		test('produces INSERT with RETURNING *', () => {
-			const { sql, params } = buildInsertQuery('users', { name: 'Alice', age: 30 })
+			const { sql, params } = buildCreateQuery('users', { name: 'Alice', age: 30 })
 			expect(sql).toBe('INSERT INTO "users" ("name", "age") VALUES ($1, $2) RETURNING *')
 			expect(params).toEqual(['Alice', 30])
 		})

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -4,15 +4,15 @@ import { FilterGroup, type FilterFactory } from '../filter'
 import { OrderBy } from '../query'
 import type { AnyPreloadDef } from '../relations'
 import type { AnySchema, SchemaOutput } from '../schema'
-import type { SchemaInsertInput, SchemaUpdateInput } from '../schema-validations'
+import type { SchemaCreateInput, SchemaUpdateInput } from '../schema-validations'
 import { applyComputedSelection, planSelection } from './internals/computeds'
 import {
+	runAllCreate,
 	runAllDelete,
-	runAllInsert,
 	runAllRead,
 	runAllUpdate,
+	runOneCreate,
 	runOneDelete,
-	runOneInsert,
 	runOneRead,
 	runOneUpdate,
 	runOneUpsert,
@@ -21,7 +21,7 @@ import { resolvePreloads } from './internals/preloads'
 import type { SelectedWithPreloads } from './internals/types'
 
 type SchemaPrimaryKeyValue<S extends AnySchema> = SchemaOutput<S>[S['pkField']['name'] & keyof SchemaOutput<S>]
-type UpsertInput<S extends AnySchema> = { insert: SchemaInsertInput<S> } | { insert: SchemaInsertInput<S>; update: SchemaUpdateInput<S> }
+type UpsertInput<S extends AnySchema> = { create: SchemaCreateInput<S> } | { create: SchemaCreateInput<S>; update: SchemaUpdateInput<S> }
 type ReadState<Sel extends string, P extends readonly AnyPreloadDef[] = readonly AnyPreloadDef[]> = {
 	where?: FilterGroup
 	select?: readonly Sel[]
@@ -158,8 +158,8 @@ export class OneBuilder<S extends AnySchema, Sel extends string, P extends reado
 		) as any
 	}
 
-	insert(data: SchemaInsertInput<S>) {
-		return runOneInsert(
+	create(data: SchemaCreateInput<S>) {
+		return runOneCreate(
 			this._context,
 			{
 				select: this._select,
@@ -262,8 +262,8 @@ export class AllBuilder<S extends AnySchema, Sel extends string, P extends reado
 		return cloned as this
 	}
 
-	insert(data: SchemaInsertInput<S>[]) {
-		return runAllInsert(
+	create(data: SchemaCreateInput<S>[]) {
+		return runAllCreate(
 			this._context,
 			{
 				select: this._select,
@@ -326,7 +326,7 @@ if (import.meta.vitest) {
 				 .field('name', v.string()),
 			)
 
-			const created = await repo.from(UserSchema).one().insert({ email: 'up@test.com', name: 'Before' })
+			const created = await repo.from(UserSchema).one().create({ email: 'up@test.com', name: 'Before' })
 			const updated = await repo.from(UserSchema).one().id(created.id).update({ name: 'After' })
 			expect(updated?.name).toBe('After')
 			const found = await repo.from(UserSchema).one().id(created.id).find()
@@ -343,7 +343,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@x.com', name: 'Alice' },
 					{ email: 'b@x.com', name: 'Bob' },
 				])
@@ -366,7 +366,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'alice@x.com', name: 'Alice' },
 					{ email: 'bob@x.com', name: 'Bob' },
 				])

--- a/src/orm/repo/internals/executors.ts
+++ b/src/orm/repo/internals/executors.ts
@@ -4,7 +4,7 @@ import type { FilterGroup } from '../../filter'
 import type { OrderBy } from '../../query'
 import type { AnyPreloadDef } from '../../relations'
 import type { AnySchema } from '../../schema'
-import { validateInsert, validateUpdate, type SchemaInsertInput, type SchemaUpdateInput } from '../../schema-validations'
+import { validateCreate, validateUpdate, type SchemaCreateInput, type SchemaUpdateInput } from '../../schema-validations'
 import { SetOp, isUpdateOp, type AnyUpdateOp } from '../../updates'
 import type { SchemaContext } from '../builders'
 
@@ -42,26 +42,26 @@ export async function runAllRead<S extends AnySchema, Sel extends string, P exte
 	return context.shapeRows(state.select, state.preloads, rows)
 }
 
-type UpsertInput<S extends AnySchema> = { insert: SchemaInsertInput<S> } | { insert: SchemaInsertInput<S>; update: SchemaUpdateInput<S> }
+type UpsertInput<S extends AnySchema> = { create: SchemaCreateInput<S> } | { create: SchemaCreateInput<S>; update: SchemaUpdateInput<S> }
 
-export async function runOneInsert<S extends AnySchema, Sel extends string, P extends readonly AnyPreloadDef[]>(
+export async function runOneCreate<S extends AnySchema, Sel extends string, P extends readonly AnyPreloadDef[]>(
 	context: SchemaContext<S>,
 	state: { select: readonly Sel[] | undefined; preloads: P },
-	data: SchemaInsertInput<S>,
+	data: SchemaCreateInput<S>,
 ): Promise<SelectedWithPreloads<S, Sel, P>> {
-	const validated = validateInsert(context.schema, data as any)
-	const row = await context.use.insertOne(validated as any)
+	const validated = validateCreate(context.schema, data as any)
+	const row = await context.use.createOne(validated as any)
 	const [resolved] = await context.shapeRows(state.select, state.preloads, [row])
 	return resolved
 }
 
-export async function runAllInsert<S extends AnySchema, Sel extends string, P extends readonly AnyPreloadDef[]>(
+export async function runAllCreate<S extends AnySchema, Sel extends string, P extends readonly AnyPreloadDef[]>(
 	context: SchemaContext<S>,
 	state: { select: readonly Sel[] | undefined; preloads: P },
-	data: SchemaInsertInput<S>[],
+	data: SchemaCreateInput<S>[],
 ): Promise<SelectedWithPreloads<S, Sel, P>[]> {
-	const validated = data.map((entry) => validateInsert(context.schema, entry as any))
-	const rows = await context.use.insertMany(validated as any)
+	const validated = data.map((entry) => validateCreate(context.schema, entry as any))
+	const rows = await context.use.createMany(validated as any)
 	return context.shapeRows(state.select, state.preloads, rows)
 }
 
@@ -90,7 +90,7 @@ export async function runOneUpsert<S extends AnySchema, Sel extends string, P ex
 	state: { where: FilterGroup; select: readonly Sel[] | undefined; preloads: P },
 	data: UpsertInput<S>,
 ): Promise<SelectedWithPreloads<S, Sel, P>> {
-	const insert = validateInsert(context.schema, data.insert as any)
+	const create = validateCreate(context.schema, data.create as any)
 	const ops: AnyUpdateOp[] = []
 	if ('update' in data) {
 		const validated = validateUpdate(context.schema, data.update as any)
@@ -106,7 +106,7 @@ export async function runOneUpsert<S extends AnySchema, Sel extends string, P ex
 			ops.unshift(new SetOp(plainValues))
 		}
 	}
-	const row = await context.use.upsertOne(state.where, insert as any, ops)
+	const row = await context.use.upsertOne(state.where, create as any, ops)
 	return (await context.shapeOneRow(state.select, state.preloads, row)) as SelectedWithPreloads<S, Sel, P>
 }
 

--- a/src/orm/repo/internals/preloads.ts
+++ b/src/orm/repo/internals/preloads.ts
@@ -250,9 +250,9 @@ if (import.meta.vitest) {
 
 		test('hasMany preload resolves related entities', async () => {
 			const Repo = makeRepo()
-			const user = await Repo.from(UserSchema).one().insert({ email: 'u@test.com', name: 'User' })
-			await Repo.from(PostSchema).one().insert({ title: 'Post 1', userId: user.id })
-			await Repo.from(PostSchema).one().insert({ title: 'Post 2', userId: user.id })
+			const user = await Repo.from(UserSchema).one().create({ email: 'u@test.com', name: 'User' })
+			await Repo.from(PostSchema).one().create({ title: 'Post 1', userId: user.id })
+			await Repo.from(PostSchema).one().create({ title: 'Post 2', userId: user.id })
 
 			const users = await Repo.from(UserSchema).all().preload([UserRels.posts]).find()
 			expect(users[0].posts).toHaveLength(2)
@@ -260,8 +260,8 @@ if (import.meta.vitest) {
 
 		test('hasOne and belongsTo preloads resolve null and non-null branches', async () => {
 			const Repo = makeRepo()
-			const user = await Repo.from(UserSchema).one().insert({ email: 'x@test.com', name: 'X' })
-			await Repo.from(ProfileSchema).one().insert({ bio: 'Hello', userId: user.id })
+			const user = await Repo.from(UserSchema).one().create({ email: 'x@test.com', name: 'X' })
+			await Repo.from(ProfileSchema).one().create({ bio: 'Hello', userId: user.id })
 
 			const users = await Repo.from(UserSchema).all().preload([UserRels.profile]).find()
 			expect(users[0].profile?.bio).toBe('Hello')
@@ -272,9 +272,9 @@ if (import.meta.vitest) {
 
 		test('nested preload resolves recursively', async () => {
 			const Repo = makeRepo()
-			const user = await Repo.from(UserSchema).one().insert({ email: 'nested@test.com', name: 'Nested User' })
-			await Repo.from(ProfileSchema).one().insert({ bio: 'Hello nested', userId: user.id })
-			await Repo.from(PostSchema).one().insert({ title: 'Nested Post', userId: user.id })
+			const user = await Repo.from(UserSchema).one().create({ email: 'nested@test.com', name: 'Nested User' })
+			await Repo.from(ProfileSchema).one().create({ bio: 'Hello nested', userId: user.id })
+			await Repo.from(PostSchema).one().create({ title: 'Nested Post', userId: user.id })
 
 			const users = await Repo.from(UserSchema)
 				.all()
@@ -294,8 +294,8 @@ if (import.meta.vitest) {
 
 		test('cycle detection throws descriptive error', async () => {
 			const Repo = makeRepo()
-			const user = await Repo.from(UserSchema).one().insert({ email: 'cycle@test.com', name: 'Cycle User' })
-			await Repo.from(PostSchema).one().insert({ title: 'Cycle Post', userId: user.id })
+			const user = await Repo.from(UserSchema).one().create({ email: 'cycle@test.com', name: 'Cycle User' })
+			await Repo.from(PostSchema).one().create({ title: 'Cycle Post', userId: user.id })
 
 			await expect(
 				Repo.from(UserSchema)
@@ -312,13 +312,13 @@ if (import.meta.vitest) {
 
 		test('depth limit throws when chain exceeds max depth', async () => {
 			const Repo = makeRepo()
-			const a = await Repo.from(ASchema).one().insert({})
-			const b = await Repo.from(BSchema).one().insert({ aId: a.id })
-			const c = await Repo.from(CSchema).one().insert({ bId: b.id })
-			const d = await Repo.from(DSchema).one().insert({ cId: c.id })
-			const e = await Repo.from(ESchema).one().insert({ dId: d.id })
-			const f = await Repo.from(FSchema).one().insert({ eId: e.id })
-			await Repo.from(GSchema).one().insert({ fId: f.id })
+			const a = await Repo.from(ASchema).one().create({})
+			const b = await Repo.from(BSchema).one().create({ aId: a.id })
+			const c = await Repo.from(CSchema).one().create({ bId: b.id })
+			const d = await Repo.from(DSchema).one().create({ cId: c.id })
+			const e = await Repo.from(ESchema).one().create({ dId: d.id })
+			const f = await Repo.from(FSchema).one().create({ eId: e.id })
+			await Repo.from(GSchema).one().create({ fId: f.id })
 
 			await expect(
 				Repo.from(ASchema)
@@ -355,7 +355,7 @@ if (import.meta.vitest) {
 
 		test('invalid nested preload definition throws a validation error', async () => {
 			const Repo = makeRepo()
-			await Repo.from(UserSchema).one().insert({ email: 'u@test.com', name: 'User' })
+			await Repo.from(UserSchema).one().create({ email: 'u@test.com', name: 'User' })
 
 			await expect(
 				Repo.from(UserSchema)
@@ -367,8 +367,8 @@ if (import.meta.vitest) {
 
 		test('findOne with preloads resolves relations', async () => {
 			const Repo = makeRepo()
-			const user = await Repo.from(UserSchema).one().insert({ email: 'u@test.com', name: 'User' })
-			await Repo.from(PostSchema).one().insert({ title: 'Post', userId: user.id })
+			const user = await Repo.from(UserSchema).one().create({ email: 'u@test.com', name: 'User' })
+			await Repo.from(PostSchema).one().create({ title: 'Post', userId: user.id })
 
 			const found = await Repo.from(UserSchema).one().id(user.id).preload([UserRels.posts]).find()
 			expect(found?.posts).toHaveLength(1)
@@ -391,13 +391,13 @@ if (import.meta.vitest) {
 			})
 
 			const Repo = defineRepo((r) => r.adapter(adapter).resolve((s) => ({ prefix: s.name })))
-			const u1 = await Repo.from(UserSchema).one().insert({ email: 'a@test.com', name: 'A' })
-			const u2 = await Repo.from(UserSchema).one().insert({ email: 'b@test.com', name: 'B' })
-			const u3 = await Repo.from(UserSchema).one().insert({ email: 'c@test.com', name: 'C' })
-			await Repo.from(PostSchema).one().insert({ title: 'P1', userId: u1.id })
-			await Repo.from(PostSchema).one().insert({ title: 'P2', userId: u1.id })
-			await Repo.from(PostSchema).one().insert({ title: 'P3', userId: u2.id })
-			await Repo.from(PostSchema).one().insert({ title: 'P4', userId: u3.id })
+			const u1 = await Repo.from(UserSchema).one().create({ email: 'a@test.com', name: 'A' })
+			const u2 = await Repo.from(UserSchema).one().create({ email: 'b@test.com', name: 'B' })
+			const u3 = await Repo.from(UserSchema).one().create({ email: 'c@test.com', name: 'C' })
+			await Repo.from(PostSchema).one().create({ title: 'P1', userId: u1.id })
+			await Repo.from(PostSchema).one().create({ title: 'P2', userId: u1.id })
+			await Repo.from(PostSchema).one().create({ title: 'P3', userId: u2.id })
+			await Repo.from(PostSchema).one().create({ title: 'P4', userId: u3.id })
 
 			queryCount = 0
 			const users = await Repo.from(UserSchema).all().preload([UserRels.posts]).find()

--- a/src/orm/repo/repo.ts
+++ b/src/orm/repo/repo.ts
@@ -3,12 +3,12 @@ import type { OrmAdapterLike } from '../adapters/base'
 import { assertNormalisedFilter, FilterGroup, type FilterFactory, type GatedFilterFactory } from '../filter'
 import type { AnySchema, SchemaOutput, SchemaPersistedOutput } from '../schema'
 import {
-	validateInsert,
-	validateInsertMany,
+	validateCreate,
+	validateCreateMany,
 	validateUpdate,
 	validateUpdateOps,
 	validateUpsertConflicts,
-	type SchemaInsertInput,
+	type SchemaCreateInput,
 	type SchemaUpdateInput,
 } from '../schema-validations'
 import type { AnyUpdateOp, UpdateOp } from '../updates'
@@ -181,19 +181,19 @@ export class Repo<A extends OrmAdapterLike<any>> {
 	async upsertOne<S extends AnySchema>(
 		schema: SchemaCompatible<A, S>,
 		filter: GatedFilterFactory<InferAdapterQueryableOps<A>>,
-		insert: SchemaInsertInput<S>,
+		create: SchemaCreateInput<S>,
 		...ops: UpdateOp<S, A>[]
 	): Promise<SchemaPersistedOutput<S>> {
 		const s = schema as unknown as AnySchema
-		const rawInsert = insert as Record<string, unknown>
+		const rawCreate = create as Record<string, unknown>
 		const castOps = ops as unknown as AnyUpdateOp[]
-		validateUpsertConflicts(s, rawInsert, castOps)
-		const validatedInsert = validateInsert(s, rawInsert)
+		validateUpsertConflicts(s, rawCreate, castOps)
+		const validatedCreate = validateCreate(s, rawCreate)
 		const validatedOps = castOps.length > 0 ? validateUpdateOps(s, castOps, 'upsertOne') : []
 		const group = (filter as unknown as FilterFactory)(FilterGroup.create())
 		assertNormalisedFilter(s, group)
 		const use = this.#getUse(s)
-		const row = await use.upsertOne(group, validatedInsert as Record<string, unknown>, validatedOps)
+		const row = await use.upsertOne(group, validatedCreate as Record<string, unknown>, validatedOps)
 		return row as SchemaPersistedOutput<S>
 	}
 
@@ -201,17 +201,17 @@ export class Repo<A extends OrmAdapterLike<any>> {
 		return this.#adapter.session(fn)
 	}
 
-	async insertOne<S extends AnySchema>(schema: S, data: SchemaInsertInput<S>): Promise<SchemaOutput<S>> {
-		const validated = validateInsert(schema, data as Record<string, unknown>)
+	async createOne<S extends AnySchema>(schema: S, data: SchemaCreateInput<S>): Promise<SchemaOutput<S>> {
+		const validated = validateCreate(schema, data as Record<string, unknown>)
 		const use = this.#getUse(schema)
-		const row = await use.insertOne(validated as Record<string, unknown>)
+		const row = await use.createOne(validated as Record<string, unknown>)
 		return row as SchemaOutput<S>
 	}
 
-	async insertMany<S extends AnySchema>(schema: S, data: SchemaInsertInput<S>[]): Promise<SchemaOutput<S>[]> {
-		const validated = validateInsertMany(schema, data as Record<string, unknown>[])
+	async createMany<S extends AnySchema>(schema: S, data: SchemaCreateInput<S>[]): Promise<SchemaOutput<S>[]> {
+		const validated = validateCreateMany(schema, data as Record<string, unknown>[])
 		const use = this.#getUse(schema)
-		const rows = await use.insertMany(validated as Record<string, unknown>[])
+		const rows = await use.createMany(validated as Record<string, unknown>[])
 		return rows as SchemaOutput<S>[]
 	}
 
@@ -330,7 +330,7 @@ if (import.meta.vitest) {
 
 		test('fluent builders support one/all read chains', async () => {
 			const repo = makeRepo()
-			const created = await repo.from(UserSchema).one().insert({ email: 'fluent@test.com', name: 'Fluent User' })
+			const created = await repo.from(UserSchema).one().create({ email: 'fluent@test.com', name: 'Fluent User' })
 
 			const one = await repo.from(UserSchema).one().id(created.id).select(['id', 'name']).find()
 			expect(one).toEqual({ id: created.id, name: 'Fluent User' })
@@ -352,7 +352,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'alice@branch.com', name: 'Alice' },
 					{ email: 'bob@branch.com', name: 'Bob' },
 				])
@@ -372,13 +372,13 @@ if (import.meta.vitest) {
 
 		test('fluent builders support write chains with preloads', async () => {
 			const repo = makeRepo()
-			const org = await repo.from(OrgSchema).one().insert({ name: 'Fluent Org' })
+			const org = await repo.from(OrgSchema).one().create({ name: 'Fluent Org' })
 
 			const user = await repo
 				.from(UserSchema)
 				.one()
 				.preload([UserRels.org])
-				.insert({ email: 'writer@test.com', name: 'Writer', orgId: org.id })
+				.create({ email: 'writer@test.com', name: 'Writer', orgId: org.id })
 
 			expect((user.org as any).name).toBe('Fluent Org')
 
@@ -394,7 +394,7 @@ if (import.meta.vitest) {
 			const repo = makeRepo()
 
 			const insertedId = await repo.session(async () => {
-				const created = await repo.from(UserSchema).one().insert({ email: 'tx@fluent.com', name: 'Tx Fluent' })
+				const created = await repo.from(UserSchema).one().create({ email: 'tx@fluent.com', name: 'Tx Fluent' })
 				await repo.from(UserSchema).one().id(created.id).update({ name: 'Tx Fluent Updated' })
 				return created.id
 			})
@@ -403,9 +403,9 @@ if (import.meta.vitest) {
 			expect(persisted).toEqual({ name: 'Tx Fluent Updated' })
 		})
 
-		test('insert/find/update/delete flows work', async () => {
+		test('create/find/update/delete flows work', async () => {
 			const repo = makeRepo()
-			const user = await repo.from(UserSchema).one().insert({ email: 'a@b.com', name: 'Alice' })
+			const user = await repo.from(UserSchema).one().create({ email: 'a@b.com', name: 'Alice' })
 			expect(user.id).toMatch(/^u\d+$/)
 			expect(user.createdAt).toBe(1000)
 
@@ -421,7 +421,7 @@ if (import.meta.vitest) {
 
 		test('findById, updateById, and deleteById target the schema primary key', async () => {
 			const repo = makeRepo()
-			const user = await repo.from(UserSchema).one().insert({ email: 'id@test.com', name: 'ById' })
+			const user = await repo.from(UserSchema).one().create({ email: 'id@test.com', name: 'ById' })
 
 			const found = await repo.from(UserSchema).one().id(user.id).find()
 			expect(found?.id).toBe(user.id)
@@ -434,12 +434,12 @@ if (import.meta.vitest) {
 			expect(await repo.from(UserSchema).one().id(user.id).find()).toBeNull()
 		})
 
-		test('insertMany, findMany and upsertOne work', async () => {
+		test('createMany, findMany and upsertOne work', async () => {
 			const repo = makeRepo()
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@b.com', name: 'Alice' },
 					{ email: 'b@c.com', name: 'Bob' },
 				])
@@ -449,7 +449,7 @@ if (import.meta.vitest) {
 				.from(UserSchema)
 				.one()
 				.where((q) => q.eq('id', 'u-fixed'))
-				.upsert({ insert: { email: 'new@test.com', name: 'New' } })
+				.upsert({ create: { email: 'new@test.com', name: 'New' } })
 			expect(inserted.name).toBe('New')
 		})
 
@@ -458,7 +458,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@b.com', name: 'Alice' },
 					{ email: 'b@c.com', name: 'Bob' },
 				])
@@ -505,7 +505,7 @@ if (import.meta.vitest) {
 			const repo = makeRepo()
 			let insertedId = ''
 			const result = await repo.session(async () => {
-				const inserted = await repo.from(UserSchema).one().insert({ email: 't@test.com', name: 'TxUser' })
+				const inserted = await repo.from(UserSchema).one().create({ email: 't@test.com', name: 'TxUser' })
 				insertedId = inserted.id
 				return 42
 			})
@@ -516,15 +516,15 @@ if (import.meta.vitest) {
 
 		test('preloads can be resolved on mutation methods', async () => {
 			const repo = makeRepo()
-			const org = await repo.from(OrgSchema).one().insert({ name: 'Corp' })
+			const org = await repo.from(OrgSchema).one().create({ name: 'Corp' })
 			const user = await repo
 				.from(UserSchema)
 				.one()
 				.preload([UserRels.org])
-				.insert({ email: 'u@test.com', name: 'User', orgId: org.id })
+				.create({ email: 'u@test.com', name: 'User', orgId: org.id })
 			expect((user.org as any).name).toBe('Corp')
 
-			await repo.from(PostSchema).one().insert({ title: 'Post', userId: user.id })
+			await repo.from(PostSchema).one().create({ title: 'Post', userId: user.id })
 			const updated = await repo.from(UserSchema).one().id(user.id).preload([UserRels.posts]).update({ name: 'Updated' })
 			expect(updated?.posts).toHaveLength(1)
 		})
@@ -541,7 +541,7 @@ if (import.meta.vitest) {
 
 		test('computed fields are derived and shaped correctly when selected', async () => {
 			const repo = makeRepo()
-			const created = await repo.from(PersonSchema).one().insert({ firstName: 'Ada', lastName: 'Lovelace' })
+			const created = await repo.from(PersonSchema).one().create({ firstName: 'Ada', lastName: 'Lovelace' })
 			const rows = await repo.from(PersonSchema).all().select(['id', 'fullName']).find()
 
 			expect(rows).toEqual([{ id: created.id, fullName: 'Ada Lovelace' }])
@@ -563,7 +563,7 @@ if (import.meta.vitest) {
 			})
 
 			const repo = defineRepo((r) => r.adapter(adapter).resolve((s) => ({ prefix: s.name })))
-			await repo.from(PersonSchema).one().insert({ firstName: 'Grace', lastName: 'Hopper' })
+			await repo.from(PersonSchema).one().create({ firstName: 'Grace', lastName: 'Hopper' })
 			await repo.from(PersonSchema).all().select(['id', 'fullName']).find()
 
 			expect(seenSelect).toEqual(expect.arrayContaining(['id', 'firstName', 'lastName']))
@@ -572,7 +572,7 @@ if (import.meta.vitest) {
 		test('unknown selected fields fail fast', async () => {
 			const { EquippedError } = await import('../../errors')
 			const repo = makeRepo()
-			await repo.from(PersonSchema).one().insert({ firstName: 'Ada', lastName: 'Lovelace' })
+			await repo.from(PersonSchema).one().create({ firstName: 'Ada', lastName: 'Lovelace' })
 
 			await expect(
 				repo
@@ -603,7 +603,7 @@ if (import.meta.vitest) {
 			})
 
 			const repo = defineRepo((r) => r.adapter(adapter).resolve((s) => ({ prefix: s.name })))
-			await repo.from(PersonSchema).one().insert({ firstName: 'Katherine', lastName: 'Johnson' })
+			await repo.from(PersonSchema).one().create({ firstName: 'Katherine', lastName: 'Johnson' })
 
 			await expect(repo.from(PersonSchema).all().select(['fullName']).find()).rejects.toBeInstanceOf(EquippedError)
 		})
@@ -614,7 +614,7 @@ if (import.meta.vitest) {
 			const repo = defineRepo((r) => r.adapter(adapter).resolve((s) => ({ prefix: s.name })))
 
 			const use = adapter.use(TestSchema, { prefix: 'findbytest' })
-			await use.insertOne({ id: 'x' })
+			await use.createOne({ id: 'x' })
 
 			const found = await repo.findByPk(TestSchema, 'x')
 			expect(found).toEqual({ id: 'x' })
@@ -623,10 +623,10 @@ if (import.meta.vitest) {
 			expect(missing).toBeNull()
 		})
 
-		describe('schema-per-call insert path', () => {
-			test('insertOne round-trip via findByPk', async () => {
+		describe('schema-per-call create path', () => {
+			test('createOne round-trip via findByPk', async () => {
 				const repo = makeRepo()
-				const inserted = await repo.insertOne(UserSchema, { email: 'rt@test.com', name: 'RoundTrip' })
+				const inserted = await repo.createOne(UserSchema, { email: 'rt@test.com', name: 'RoundTrip' })
 				expect(inserted.email).toBe('rt@test.com')
 				expect(inserted.name).toBe('RoundTrip')
 				expect(inserted.id).toBeDefined()
@@ -637,33 +637,33 @@ if (import.meta.vitest) {
 				expect(found!.email).toBe('rt@test.com')
 			})
 
-			test('insertOne injects onCreate defaults for missing fields', async () => {
+			test('createOne injects onCreate defaults for missing fields', async () => {
 				const repo = makeRepo()
-				const inserted = await repo.insertOne(UserSchema, { email: 'defaults@test.com', name: 'Defaults' })
+				const inserted = await repo.createOne(UserSchema, { email: 'defaults@test.com', name: 'Defaults' })
 				expect(inserted.createdAt).toBe(1000)
 				expect(inserted.id).toBeDefined()
 			})
 
-			test('insertOne throws OrmValidationError with kind validation and field populated', async () => {
+			test('createOne throws OrmValidationError with kind validation and field populated', async () => {
 				const { OrmValidationError } = await import('../schema-validations')
 				const repo = makeRepo()
 				try {
-					await repo.insertOne(UserSchema, { email: 123 as any, name: 'Bad' })
+					await repo.createOne(UserSchema, { email: 123 as any, name: 'Bad' })
 					expect.unreachable()
 				} catch (e) {
 					expect(e).toBeInstanceOf(OrmValidationError)
 					const err = e as InstanceType<typeof OrmValidationError>
 					expect(err.kind).toBe('validation')
-					expect(err.operation).toBe('insertOne')
+					expect(err.operation).toBe('createOne')
 					expect(err.schema).toBe('users')
 					expect(err.failures.length).toBeGreaterThan(0)
 					expect(err.failures[0].field).toBe('email')
 				}
 			})
 
-			test('insertMany round-trip via findByPk', async () => {
+			test('createMany round-trip via findByPk', async () => {
 				const repo = makeRepo()
-				const inserted = await repo.insertMany(UserSchema, [
+				const inserted = await repo.createMany(UserSchema, [
 					{ email: 'a@test.com', name: 'Alice' },
 					{ email: 'b@test.com', name: 'Bob' },
 				])
@@ -675,11 +675,11 @@ if (import.meta.vitest) {
 				expect(foundB!.email).toBe('b@test.com')
 			})
 
-			test('insertMany collects all failures with rowIndex and throws single OrmValidationError', async () => {
+			test('createMany collects all failures with rowIndex and throws single OrmValidationError', async () => {
 				const { OrmValidationError } = await import('../schema-validations')
 				const repo = makeRepo()
 				try {
-					await repo.insertMany(UserSchema, [
+					await repo.createMany(UserSchema, [
 						{ email: 'good@test.com', name: 'Good' },
 						{ email: 123 as any, name: 'Bad' },
 						{ email: 'also-bad' as any, name: 456 as any },
@@ -689,7 +689,7 @@ if (import.meta.vitest) {
 					expect(e).toBeInstanceOf(OrmValidationError)
 					const err = e as InstanceType<typeof OrmValidationError>
 					expect(err.kind).toBe('validation')
-					expect(err.operation).toBe('insertMany')
+					expect(err.operation).toBe('createMany')
 					expect(err.schema).toBe('users')
 					const rowIndices = err.failures.map((f) => f.rowIndex)
 					expect(rowIndices).toContain(1)
@@ -704,9 +704,9 @@ if (import.meta.vitest) {
 				expect(result).toBeNull()
 			})
 
-			test('insertMany with onCreate defaults applied to all rows', async () => {
+			test('createMany with onCreate defaults applied to all rows', async () => {
 				const repo = makeRepo()
-				const inserted = await repo.insertMany(UserSchema, [
+				const inserted = await repo.createMany(UserSchema, [
 					{ email: 'x@test.com', name: 'X' },
 					{ email: 'y@test.com', name: 'Y' },
 				])
@@ -719,7 +719,7 @@ if (import.meta.vitest) {
 
 		test('repo.deleteByPk removes and returns document, null for missing', async () => {
 			const repo = makeRepo()
-			const user = await repo.from(UserSchema).one().insert({ email: 'del@test.com', name: 'ToDelete' })
+			const user = await repo.from(UserSchema).one().create({ email: 'del@test.com', name: 'ToDelete' })
 
 			const deleted = await repo.deleteByPk(UserSchema, user.id)
 			expect(deleted).toEqual(expect.objectContaining({ id: user.id, name: 'ToDelete' }))
@@ -742,7 +742,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@test.com', name: 'Alice' },
 					{ email: 'b@test.com', name: 'Bob' },
 				])
@@ -756,7 +756,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@test.com', name: 'Same' },
 					{ email: 'b@test.com', name: 'Same' },
 				])
@@ -774,7 +774,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@test.com', name: 'Same' },
 					{ email: 'b@test.com', name: 'Same' },
 					{ email: 'c@test.com', name: 'Different' },
@@ -793,7 +793,7 @@ if (import.meta.vitest) {
 					.field('updatedAt', v.number(), { onCreate: () => 0, onUpdate: () => 9999 }),
 			)
 			const repo = makeRepo()
-			await repo.from(AutoSchema).one().insert({ name: 'A' })
+			await repo.from(AutoSchema).one().create({ name: 'A' })
 
 			const updated = await repo.updateMany(AutoSchema, (q) => q.eq('name', 'A'), { name: 'B' })
 			expect(updated[0].updatedAt).toBe(9999)
@@ -804,7 +804,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@test.com', name: 'Alice' },
 					{ email: 'b@test.com', name: 'Bob' },
 				])
@@ -821,7 +821,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(UserSchema)
 				.all()
-				.insert([
+				.create([
 					{ email: 'a@test.com', name: 'ToDelete' },
 					{ email: 'b@test.com', name: 'ToDelete' },
 					{ email: 'c@test.com', name: 'Keep' },
@@ -837,7 +837,7 @@ if (import.meta.vitest) {
 
 		test('round-trip update via filter preserves data integrity', async () => {
 			const repo = makeRepo()
-			const user = await repo.from(UserSchema).one().insert({ email: 'rt@test.com', name: 'Original' })
+			const user = await repo.from(UserSchema).one().create({ email: 'rt@test.com', name: 'Original' })
 
 			await repo.updateOne(UserSchema, (q) => q.eq('id', user.id), { name: 'Modified' })
 
@@ -897,7 +897,7 @@ if (import.meta.vitest) {
 			await repo
 				.from(TestSchema)
 				.all()
-				.insert([
+				.create([
 					{ name: 'Alice', age: 30, active: true, tags: ['admin', 'user'] },
 					{ name: 'Bob', age: 20, active: false, tags: ['user'] },
 					{ name: 'Carol', age: 40, active: true, tags: ['admin'] },
@@ -1216,7 +1216,7 @@ if (import.meta.vitest) {
 		test('round-trip update via updateByPk', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpdateRepo()
-			const item = await repo.from(ItemSchema).one().insert({ title: 'Hello', views: 0 })
+			const item = await repo.from(ItemSchema).one().create({ title: 'Hello', views: 0 })
 			const updated = await repo.updateByPk(ItemSchema, item.id, set<typeof ItemSchema>({ title: 'Updated' }))
 			expect(updated).not.toBeNull()
 			expect(updated!.title).toBe('Updated')
@@ -1229,7 +1229,7 @@ if (import.meta.vitest) {
 		test('auto-bump injects updatedAt on un-touched onUpdate field', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpdateRepo()
-			const item = await repo.from(ItemSchema).one().insert({ title: 'Hello', views: 0 })
+			const item = await repo.from(ItemSchema).one().create({ title: 'Hello', views: 0 })
 			const before = item.updatedAt
 
 			const updated = await repo.updateByPk(ItemSchema, item.id, set<typeof ItemSchema>({ title: 'Changed' }))
@@ -1240,7 +1240,7 @@ if (import.meta.vitest) {
 		test('user set({updatedAt:X}) suppresses auto-bump', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpdateRepo()
-			const item = await repo.from(ItemSchema).one().insert({ title: 'Hello', views: 0 })
+			const item = await repo.from(ItemSchema).one().create({ title: 'Hello', views: 0 })
 
 			const updated = await repo.updateByPk(ItemSchema, item.id, set<typeof ItemSchema>({ updatedAt: 9999 }))
 			expect(updated!.updatedAt).toBe(9999)
@@ -1250,7 +1250,7 @@ if (import.meta.vitest) {
 			const { set, inc } = await import('../updates')
 			const { OrmValidationError } = await import('../schema-validations')
 			const repo = makeUpdateRepo()
-			const item = await repo.from(ItemSchema).one().insert({ title: 'Hello', views: 0 })
+			const item = await repo.from(ItemSchema).one().create({ title: 'Hello', views: 0 })
 
 			await expect(
 				repo.updateByPk(
@@ -1278,7 +1278,7 @@ if (import.meta.vitest) {
 		test('updateByPk with inc op', async () => {
 			const { inc } = await import('../updates')
 			const repo = makeUpdateRepo()
-			const item = await repo.from(ItemSchema).one().insert({ title: 'Hello', views: 10 })
+			const item = await repo.from(ItemSchema).one().create({ title: 'Hello', views: 10 })
 
 			const updated = await repo.updateByPk(ItemSchema, item.id, inc<typeof ItemSchema>(ItemSchema.fields.views, 5))
 			expect(updated!.views).toBe(15)
@@ -1316,7 +1316,7 @@ if (import.meta.vitest) {
 			return defineRepo((r) => r.adapter(adapter).resolve((s) => ({ prefix: s.name })))
 		}
 
-		test('insert-then-ops path: row missing → inserts and applies ops', async () => {
+		test('create-then-ops path: row missing → creates and applies ops', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpsertRepo()
 
@@ -1332,7 +1332,7 @@ if (import.meta.vitest) {
 			expect(result.createdAt).toBe(1000)
 		})
 
-		test('insert path with set op overriding insert field is allowed', async () => {
+		test('create path with set op overriding create field is allowed', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpsertRepo()
 
@@ -1347,11 +1347,11 @@ if (import.meta.vitest) {
 			expect(result.name).toBe('Original')
 		})
 
-		test('update-only-on-exists path: row exists → ignores insert, applies ops + auto-bump', async () => {
+		test('update-only-on-exists path: row exists → ignores create, applies ops + auto-bump', async () => {
 			const { set } = await import('../updates')
 			const repo = makeUpsertRepo()
 
-			await repo.insertOne(UpsertSchema, { email: 'bob@test.com', name: 'Bob', views: 42 })
+			await repo.createOne(UpsertSchema, { email: 'bob@test.com', name: 'Bob', views: 42 })
 
 			const result = await repo.upsertOne(
 				UpsertSchema,
@@ -1365,7 +1365,7 @@ if (import.meta.vitest) {
 			expect(result.updatedAt).toBe(9999)
 		})
 
-		test('insert-vs-op conflict throws OrmValidationError with kind conflicting-ops', async () => {
+		test('create-vs-op conflict throws OrmValidationError with kind conflicting-ops', async () => {
 			const { inc } = await import('../updates')
 			const { OrmValidationError } = await import('../schema-validations')
 			const repo = makeUpsertRepo()
@@ -1387,7 +1387,7 @@ if (import.meta.vitest) {
 			}
 		})
 
-		test('empty-ops-allowed-on-upsert: insert with no ops is allowed', async () => {
+		test('empty-ops-allowed-on-upsert: create with no ops is allowed', async () => {
 			const repo = makeUpsertRepo()
 
 			const result = await repo.upsertOne(UpsertSchema, (q) => q.eq('email', 'noops@test.com'), {
@@ -1403,7 +1403,7 @@ if (import.meta.vitest) {
 		test('empty-ops-allowed-on-upsert: if exists do nothing', async () => {
 			const repo = makeUpsertRepo()
 
-			await repo.insertOne(UpsertSchema, { email: 'exists@test.com', name: 'Original', views: 5 })
+			await repo.createOne(UpsertSchema, { email: 'exists@test.com', name: 'Original', views: 5 })
 
 			const result = await repo.upsertOne(UpsertSchema, (q) => q.eq('email', 'exists@test.com'), {
 				email: 'exists@test.com',
@@ -1437,7 +1437,7 @@ if (import.meta.vitest) {
 			expect(updateResult.name).toBe('DocUpdated')
 		})
 
-		test('validates insert payload via validateInsert (onCreate defaults injected)', async () => {
+		test('validates create payload via validateCreate (onCreate defaults injected)', async () => {
 			const repo = makeUpsertRepo()
 
 			const result = await repo.upsertOne(UpsertSchema, (q) => q.eq('email', 'defaults@test.com'), {
@@ -1450,7 +1450,7 @@ if (import.meta.vitest) {
 			expect(result.createdAt).toBe(1000)
 		})
 
-		test('validates insert payload and throws OrmValidationError on invalid', async () => {
+		test('validates create payload and throws OrmValidationError on invalid', async () => {
 			const { OrmValidationError } = await import('../schema-validations')
 			const repo = makeUpsertRepo()
 
@@ -1556,12 +1556,12 @@ if (import.meta.vitest) {
 
 		test('throw-to-rollback: uncaught throw rolls back all writes and rejects with same error', async () => {
 			const repo = makeSessionRepo()
-			await repo.insertOne(SchemaA, { balance: 100 })
+			await repo.createOne(SchemaA, { balance: 100 })
 
 			const err = new Error('boom')
 			await expect(
 				repo.session(async () => {
-					await repo.insertOne(SchemaA, { balance: 200 })
+					await repo.createOne(SchemaA, { balance: 200 })
 					throw err
 				}),
 			).rejects.toBe(err)
@@ -1574,7 +1574,7 @@ if (import.meta.vitest) {
 		test('return-to-commit: successful return commits and resolves with callback value', async () => {
 			const repo = makeSessionRepo()
 			const result = await repo.session(async () => {
-				await repo.insertOne(SchemaA, { balance: 500 })
+				await repo.createOne(SchemaA, { balance: 500 })
 				return 'committed'
 			})
 
@@ -1586,12 +1586,12 @@ if (import.meta.vitest) {
 
 		test('cross-schema session: multiple schemas share one tx; on throw both roll back', async () => {
 			const repo = makeSessionRepo()
-			const account = await repo.insertOne(SchemaA, { balance: 1000 })
+			const account = await repo.createOne(SchemaA, { balance: 1000 })
 
 			await expect(
 				repo.session(async () => {
 					await repo.updateMany(SchemaA, (q) => q.eq('id', account.id), { balance: 900 })
-					await repo.insertOne(SchemaB, { amount: 100, accountId: account.id })
+					await repo.createOne(SchemaB, { amount: 100, accountId: account.id })
 					throw new Error('tx failure')
 				}),
 			).rejects.toThrow('tx failure')
@@ -1607,9 +1607,9 @@ if (import.meta.vitest) {
 			const repo = makeSessionRepo()
 
 			const result = await repo.session(async () => {
-				await repo.insertOne(SchemaA, { balance: 100 })
+				await repo.createOne(SchemaA, { balance: 100 })
 				const inner = await repo.session(async () => {
-					await repo.insertOne(SchemaA, { balance: 200 })
+					await repo.createOne(SchemaA, { balance: 200 })
 					return 'inner'
 				})
 				return inner
@@ -1622,13 +1622,13 @@ if (import.meta.vitest) {
 
 		test('nested session: throw in inner rolls back entire outer tx (flat nesting)', async () => {
 			const repo = makeSessionRepo()
-			await repo.insertOne(SchemaA, { balance: 50 })
+			await repo.createOne(SchemaA, { balance: 50 })
 
 			await expect(
 				repo.session(async () => {
-					await repo.insertOne(SchemaA, { balance: 100 })
+					await repo.createOne(SchemaA, { balance: 100 })
 					await repo.session(async () => {
-						await repo.insertOne(SchemaA, { balance: 200 })
+						await repo.createOne(SchemaA, { balance: 200 })
 						throw new Error('inner boom')
 					})
 				}),

--- a/src/orm/schema-validations.ts
+++ b/src/orm/schema-validations.ts
@@ -6,7 +6,7 @@ import { Schema, defineSchema, type AnySchema, type SchemaFields, type SchemaOut
 import { SetOp, isUpdateOp, opTouchedFields, type AnyUpdateOp } from './updates'
 import type { Prettify } from './utils'
 
-export type SchemaInsertInput<S extends AnySchema> = Prettify<
+export type SchemaCreateInput<S extends AnySchema> = Prettify<
 	{
 		[K in keyof SchemaFields<S> as SchemaFields<S>[K] extends SchemaField<any, any, true>
 			? never
@@ -28,7 +28,7 @@ export type SchemaUpdateOutput<S extends AnySchema> =
 		? { [K in keyof F]?: F[K] extends AnySchemaField ? PipeOutput<F[K]['pipe']> | AnyUpdateOp : never }
 		: Record<string, unknown>
 
-export function tryValidateInsertRow<S extends AnySchema>(
+export function tryValidateCreateRow<S extends AnySchema>(
 	s: S,
 	data: Record<string, unknown>,
 ): { ok: true; value: SchemaOutput<S> } | { ok: false; failures: OrmValidationFailure[] } {
@@ -50,20 +50,20 @@ export function tryValidateInsertRow<S extends AnySchema>(
 	return { ok: true, value: result as SchemaOutput<S> }
 }
 
-export function validateInsert<S extends AnySchema>(s: S, data: Record<string, unknown>): SchemaOutput<S> {
-	const result = tryValidateInsertRow(s, data)
+export function validateCreate<S extends AnySchema>(s: S, data: Record<string, unknown>): SchemaOutput<S> {
+	const result = tryValidateCreateRow(s, data)
 	if (!result.ok) {
-		throw new OrmValidationError('validation', s.name, 'insertOne', result.failures)
+		throw new OrmValidationError('validation', s.name, 'createOne', result.failures)
 	}
 	return result.value
 }
 
-export function validateInsertMany<S extends AnySchema>(s: S, rows: Record<string, unknown>[]): SchemaOutput<S>[] {
+export function validateCreateMany<S extends AnySchema>(s: S, rows: Record<string, unknown>[]): SchemaOutput<S>[] {
 	const allFailures: OrmValidationFailure[] = []
 	const validated: SchemaOutput<S>[] = []
 
 	for (let i = 0; i < rows.length; i++) {
-		const result = tryValidateInsertRow(s, rows[i])
+		const result = tryValidateCreateRow(s, rows[i])
 		if (result.ok) {
 			validated.push(result.value)
 		} else {
@@ -74,7 +74,7 @@ export function validateInsertMany<S extends AnySchema>(s: S, rows: Record<strin
 	}
 
 	if (allFailures.length > 0) {
-		throw new OrmValidationError('validation', s.name, 'insertMany', allFailures)
+		throw new OrmValidationError('validation', s.name, 'createMany', allFailures)
 	}
 
 	return validated
@@ -177,16 +177,16 @@ export function validateUpdateOps(schema: AnySchema, ops: AnyUpdateOp[], operati
 
 export function validateUpsertConflicts(
 	schema: AnySchema,
-	rawInsert: Record<string, unknown>,
+	rawCreate: Record<string, unknown>,
 	ops: AnyUpdateOp[],
 ): void {
-	const insertFields = new Set(Object.keys(rawInsert))
+	const createFields = new Set(Object.keys(rawCreate))
 	const conflicts: OrmValidationFailure[] = []
 	for (const op of ops) {
 		if (op instanceof SetOp) continue
 		for (const field of opTouchedFields(op)) {
-			if (insertFields.has(field)) {
-				conflicts.push({ field, cause: `field "${field}" present in both insert payload and atomic op "${op.kind}"` })
+			if (createFields.has(field)) {
+				conflicts.push({ field, cause: `field "${field}" present in both create payload and atomic op "${op.kind}"` })
 			}
 		}
 	}
@@ -199,7 +199,7 @@ if (import.meta.vitest) {
 	const { describe, test, expect } = import.meta.vitest
 	const { IncOp, MulOp, SetOp, UnsetOp } = await import('./updates')
 
-	describe('validateInsert', () => {
+	describe('validateCreate', () => {
 		const UserSchema = defineSchema('users', (s) =>
 			s.pk('id', v.string(), () => 'auto-id')
 			 .field('email', v.string())
@@ -209,45 +209,45 @@ if (import.meta.vitest) {
 		)
 
 		test('generates pk when not provided', () => {
-			const result = validateInsert(UserSchema, { email: 'a@b.com', name: 'Alice' })
+			const result = validateCreate(UserSchema, { email: 'a@b.com', name: 'Alice' })
 			expect(result.id).toBe('auto-id')
 		})
 
 		test('uses provided pk when given', () => {
-			const result = validateInsert(UserSchema, { id: 'custom-id', email: 'a@b.com', name: 'Alice' })
+			const result = validateCreate(UserSchema, { id: 'custom-id', email: 'a@b.com', name: 'Alice' })
 			expect(result.id).toBe('custom-id')
 		})
 
 		test('applies onCreate generator for generated fields', () => {
-			const result = validateInsert(UserSchema, { email: 'a@b.com', name: 'Alice' })
+			const result = validateCreate(UserSchema, { email: 'a@b.com', name: 'Alice' })
 			expect(result.createdAt).toBe(1000)
 		})
 
 		test('allows overriding generated field values', () => {
-			const result = validateInsert(UserSchema, { email: 'a@b.com', name: 'Alice', createdAt: 9999 })
+			const result = validateCreate(UserSchema, { email: 'a@b.com', name: 'Alice', createdAt: 9999 })
 			expect(result.createdAt).toBe(9999)
 		})
 
 		test('optional fields default to undefined when not provided', () => {
-			const result = validateInsert(UserSchema, { email: 'a@b.com', name: 'Alice' })
+			const result = validateCreate(UserSchema, { email: 'a@b.com', name: 'Alice' })
 			expect(result.age).toBeUndefined()
 		})
 
 		test('strips unknown fields', () => {
-			const result = validateInsert(UserSchema, { email: 'a@b.com', name: 'Alice', admin: true })
+			const result = validateCreate(UserSchema, { email: 'a@b.com', name: 'Alice', admin: true })
 			expect((result as any).admin).toBeUndefined()
 		})
 
 		test('throws OrmValidationError on invalid field type', () => {
 			try {
-				validateInsert(UserSchema, { email: 123, name: 'Alice' })
+				validateCreate(UserSchema, { email: 123, name: 'Alice' })
 				expect.unreachable()
 			} catch (e) {
 				expect(e).toBeInstanceOf(OrmValidationError)
 				const err = e as InstanceType<typeof OrmValidationError>
 				expect(err.kind).toBe('validation')
 				expect(err.schema).toBe('users')
-				expect(err.operation).toBe('insertOne')
+				expect(err.operation).toBe('createOne')
 				expect(err.failures.length).toBeGreaterThan(0)
 				expect(err.failures[0].field).toBe('email')
 			}
@@ -255,7 +255,7 @@ if (import.meta.vitest) {
 
 		test('throws OrmValidationError when required field is missing', () => {
 			try {
-				validateInsert(UserSchema, { email: 'a@b.com' })
+				validateCreate(UserSchema, { email: 'a@b.com' })
 				expect.unreachable()
 			} catch (e) {
 				expect(e).toBeInstanceOf(OrmValidationError)
@@ -267,7 +267,7 @@ if (import.meta.vitest) {
 
 		test('collects all field failures in a single error', () => {
 			try {
-				validateInsert(UserSchema, { email: 123, name: 456 })
+				validateCreate(UserSchema, { email: 123, name: 456 })
 				expect.unreachable()
 			} catch (e) {
 				expect(e).toBeInstanceOf(OrmValidationError)
@@ -279,7 +279,7 @@ if (import.meta.vitest) {
 		})
 	})
 
-	describe('validateInsertMany', () => {
+	describe('validateCreateMany', () => {
 		const ItemSchema = defineSchema('items', (s) =>
 			s.pk('id', v.string(), () => 'item-id')
 			 .field('title', v.string())
@@ -287,7 +287,7 @@ if (import.meta.vitest) {
 		)
 
 		test('validates all rows and returns validated documents', () => {
-			const results = validateInsertMany(ItemSchema, [
+			const results = validateCreateMany(ItemSchema, [
 				{ title: 'A', price: 10 },
 				{ title: 'B', price: 20 },
 			])
@@ -298,7 +298,7 @@ if (import.meta.vitest) {
 
 		test('collects failures across rows with rowIndex populated', () => {
 			try {
-				validateInsertMany(ItemSchema, [
+				validateCreateMany(ItemSchema, [
 					{ title: 'Good', price: 10 },
 					{ title: 123, price: 20 },
 					{ title: 'Also bad', price: 'not-a-number' },
@@ -309,7 +309,7 @@ if (import.meta.vitest) {
 				const err = e as InstanceType<typeof OrmValidationError>
 				expect(err.kind).toBe('validation')
 				expect(err.schema).toBe('items')
-				expect(err.operation).toBe('insertMany')
+				expect(err.operation).toBe('createMany')
 				expect(err.failures.length).toBeGreaterThanOrEqual(2)
 				const rowIndices = err.failures.map((f) => f.rowIndex)
 				expect(rowIndices).toContain(1)
@@ -320,7 +320,7 @@ if (import.meta.vitest) {
 
 		test('throws single error even with multiple bad rows', () => {
 			try {
-				validateInsertMany(ItemSchema, [
+				validateCreateMany(ItemSchema, [
 					{ title: 1, price: 'bad' },
 					{ title: 2, price: 'worse' },
 				])


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #29.

Closes #29

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._