### PR TITLE
Sandcastle: ORM: rework raw typing — adapter declares arg-tuple via signature (#33)

### DIFF
--- a/src/orm/adapter.ts
+++ b/src/orm/adapter.ts
@@ -34,7 +34,7 @@ export type CrudBag<Config> = {
 		ops: AnyUpdateOp[],
 	) => Promise<Record<string, unknown> | null>
 	deleteByPk?: (schema: AnySchema, config: Config, pk: unknown) => Promise<Record<string, unknown> | null>
-	raw?: <T = unknown>(schema: AnySchema, config: Config, command: unknown, params?: unknown[]) => Promise<T>
+	raw?: (schema: AnySchema, config: Config, ...args: any[]) => Promise<any>
 }
 
 export type QueryableBag<Config> = {
@@ -186,8 +186,8 @@ export class AdapterBuilder<Acc = {}> {
 				},
 				deleteMany: (filter) =>
 					queryable?.deleteMany?.(schema, config, filter) ?? Promise.resolve([]),
-				raw: <T = unknown>(command: unknown, params?: unknown[]) =>
-					(crud?.raw?.(schema, config, command, params) ?? Promise.reject(new Error('raw not implemented'))) as Promise<T>,
+				raw: (...args: any[]) =>
+					crud?.raw?.(schema, config, ...args) ?? Promise.reject(new Error('raw not implemented')),
 			}
 			return use
 		}
@@ -230,6 +230,14 @@ export type InferAdapterConfig<A> = A extends { __config: infer C }
 export type InferAdapterQueryableOps<A> = A extends { queryableOps: infer Ops extends readonly FilterOpName[] }
 	? Ops
 	: readonly []
+
+export type InferRawArgs<A> = A extends { crud: { raw: (schema: any, config: any, ...args: infer Args) => any } }
+	? Args
+	: never
+
+export type InferRawReturn<A> = A extends { crud: { raw: (...args: any[]) => Promise<infer R> } }
+	? R
+	: unknown
 
 type ToFieldTypeName<T> = T extends undefined
 	? never
@@ -297,6 +305,41 @@ if (import.meta.vitest) {
 		test('duplicate .supportedFieldTypes values is a TS error', () => {
 			// @ts-expect-error — duplicate 'string' should fail
 			Adapter.from<unknown>().supportedFieldTypes('string', 'string')
+		})
+	})
+
+	describe('type-level: InferRawArgs and InferRawReturn', () => {
+		test('InferRawArgs extracts user args from adapter raw signature', () => {
+			const _adapter = Adapter.from<{ table: string }>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_s: AnySchema, _c: { table: string }, _sql: string, _params: number[]) => [42],
+				})
+				.build()
+			type Args = InferRawArgs<typeof _adapter>
+			expectTypeOf<Args>().toEqualTypeOf<[sql: string, params: number[]]>()
+		})
+
+		test('InferRawReturn extracts return type from adapter raw signature', () => {
+			const _adapter = Adapter.from<{ table: string }>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_s: AnySchema, _c: { table: string }, _sql: string) => ({ rows: [] as unknown[] }),
+				})
+				.build()
+			type Ret = InferRawReturn<typeof _adapter>
+			expectTypeOf<Ret>().toEqualTypeOf<{ rows: unknown[] }>()
+		})
+
+		test('InferRawArgs returns never when adapter has no raw', () => {
+			const _adapter = Adapter.from<unknown>()
+				.supportedFieldTypes('string')
+				.crud({ findByPk: async () => null })
+				.build()
+			type Args = InferRawArgs<typeof _adapter>
+			expectTypeOf<Args>().toBeNever()
 		})
 	})
 

--- a/src/orm/adapters/base.ts
+++ b/src/orm/adapters/base.ts
@@ -17,7 +17,7 @@ export type OrmUse = {
 	) => Promise<Record<string, unknown>>
 	deleteOne: (filter: FilterGroup) => Promise<Record<string, unknown> | null>
 	deleteMany: (filter: FilterGroup) => Promise<Record<string, unknown>[]>
-	raw: <T = unknown>(command: unknown, params?: unknown[]) => Promise<T>
+	raw: (...args: any[]) => Promise<any>
 }
 
 export type OrmAdapterLike<Config extends object = object> = {

--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { differ } from 'valleyed'
 
-import { EquippedError } from '../../../errors'
 import { Adapter } from '../../adapter'
 import { Filter, FilterGroup, type FilterChild } from '../../filter'
 import type { QueryOptions } from '../../query'
@@ -278,12 +277,6 @@ export function createInMemoryAdapter() {
 				const updated = applyOps(doc, ops)
 				store.set(pkStr, updated)
 				return clone(updated)
-			},
-			raw: async () => {
-				throw new EquippedError('In-memory adapter does not support raw operations', {
-					adapter: 'in-memory',
-					operation: 'raw',
-				})
 			},
 		})
 		.queryable({

--- a/src/orm/adapters/json/index.ts
+++ b/src/orm/adapters/json/index.ts
@@ -1,6 +1,5 @@
 import { writeFile, readFile, rename } from 'node:fs/promises'
 
-import { EquippedError } from '../../../errors'
 import { Adapter } from '../../adapter'
 import { createInMemoryAdapter, type InMemoryRepoConfig } from '../in-memory'
 
@@ -80,12 +79,6 @@ export function createJsonAdapter(options: { filePath: string }) {
 				const result = await inMemory.crud.deleteByPk!(schema, config, pk)
 				if (result) await persistToDisk()
 				return result
-			},
-			raw: async () => {
-				throw new EquippedError('JSON adapter does not support raw operations', {
-					adapter: 'json',
-					operation: 'raw',
-				})
 			},
 		})
 		.queryable({

--- a/src/orm/adapters/mongodb/index.ts
+++ b/src/orm/adapters/mongodb/index.ts
@@ -400,6 +400,26 @@ if (import.meta.vitest) {
 			expectTypeOf(_ref.raw<{ total: number }[]>).returns.toEqualTypeOf<Promise<{ total: number }[]>>()
 		})
 
+		test('raw forwards pipeline to collection.aggregate at runtime', async () => {
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const schema = Schema.from('mongo_raw').pk('id', v.string(), () => 'x').build()
+			const { adapter, client } = createMongoAdapter({ host: 'localhost', port: 27017 })
+			let capturedPipeline: unknown
+			const mockResults = [{ total: 42 }]
+			;(client as any).db = () => ({
+				collection: () => ({
+					aggregate: (pipeline: unknown, _opts: unknown) => {
+						capturedPipeline = pipeline
+						return { toArray: async () => mockResults }
+					},
+				}),
+			})
+			const result = await adapter.use(schema, { db: 'testdb', col: 'things' }).raw([{ $count: 'total' }])
+			expect(capturedPipeline).toEqual([{ $count: 'total' }])
+			expect(result).toEqual(mockResults)
+		})
+
 		test('nested session returns callback without starting new transaction', () => {
 			const { adapter } = createMongoAdapter({ host: 'localhost', port: 27017 })
 			expect(adapter.transactional!.session).toBeDefined()

--- a/src/orm/adapters/mongodb/index.ts
+++ b/src/orm/adapters/mongodb/index.ts
@@ -132,18 +132,11 @@ export function createMongoAdapter(connectionConfig: MongoDbConnectionConfig) {
 					)
 				}
 			},
-			raw: async <T = unknown>(_schema: AnySchema, config: MongoDbRepoConfig, command: unknown) => {
+			raw: async (_schema: AnySchema, config: MongoDbRepoConfig, pipeline: Record<string, unknown>[]) => {
 				try {
 					const collection = getCollection(config)
-					if (!command || typeof command !== 'object') {
-						throw new EquippedError('MongoDB raw requires a command object', {
-							adapter: 'mongodb',
-							operation: 'raw',
-							collection: config.col,
-						})
-					}
-					const result = await collection.aggregate(command as any[], { session: sessionStore.getStore() }).toArray()
-					return result as T
+					const result = await collection.aggregate(pipeline, { session: sessionStore.getStore() }).toArray()
+					return result
 				} catch (error) {
 					if (error instanceof EquippedError) throw error
 					throw new EquippedError(
@@ -381,6 +374,30 @@ if (import.meta.vitest) {
 			expectTypeOf(_all.delete).toBeFunction()
 			expectTypeOf(_ref.raw).toBeFunction()
 			expectTypeOf(repo.session).toBeFunction()
+		})
+
+		test('type-level: raw arg-tuple infers (pipeline: Record<string, unknown>[]) from Mongo adapter', async () => {
+			const { Repo } = await import('../../repo/repo')
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const { adapter } = createMongoAdapter({ host: 'localhost', port: 27017 })
+			const repo = Repo.from(adapter).resolve(() => ({ db: 'test', col: 'test' })).build()
+			const _TestSchema = Schema.from('test').pk('id', v.string(), () => 'x').build()
+			const _ref = repo.on(_TestSchema)
+
+			expectTypeOf(_ref.raw).parameters.toEqualTypeOf<[pipeline: Record<string, unknown>[]]>()
+		})
+
+		test('type-level: per-call <T> override narrows Mongo raw return type', async () => {
+			const { Repo } = await import('../../repo/repo')
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const { adapter } = createMongoAdapter({ host: 'localhost', port: 27017 })
+			const repo = Repo.from(adapter).resolve(() => ({ db: 'test', col: 'test' })).build()
+			const _TestSchema = Schema.from('test').pk('id', v.string(), () => 'x').build()
+			const _ref = repo.on(_TestSchema)
+
+			expectTypeOf(_ref.raw<{ total: number }[]>).returns.toEqualTypeOf<Promise<{ total: number }[]>>()
 		})
 
 		test('nested session returns callback without starting new transaction', () => {

--- a/src/orm/adapters/postgresql/index.ts
+++ b/src/orm/adapters/postgresql/index.ts
@@ -134,17 +134,10 @@ export function createPostgresAdapter(connectionConfig: PostgresqlConnectionConf
 					)
 				}
 			},
-			raw: async <T = unknown>(_schema: AnySchema, config: PostgresqlRepoConfig, command: unknown, params: unknown[] = []) => {
+			raw: async (_schema: AnySchema, config: PostgresqlRepoConfig, command: string, params: unknown[] = []) => {
 				try {
-					if (typeof command !== 'string') {
-						throw new EquippedError('PostgreSQL raw requires a SQL string command', {
-							adapter: 'postgresql',
-							operation: 'raw',
-							table: config.table,
-						})
-					}
 					const result = await getClient().query(command, params)
-					return result as T
+					return result
 				} catch (error) {
 					if (error instanceof EquippedError) throw error
 					throw new EquippedError(
@@ -401,6 +394,42 @@ if (import.meta.vitest) {
 			expectTypeOf(_all.delete).toBeFunction()
 			expectTypeOf(_ref.raw).toBeFunction()
 			expectTypeOf(repo.session).toBeFunction()
+		})
+
+		test('type-level: raw arg-tuple infers (command: string, params?: unknown[]) from PG adapter', async () => {
+			const { Repo } = await import('../../repo/repo')
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			const repo = Repo.from(adapter).resolve(() => ({ table: 'test' })).build()
+			const _TestSchema = Schema.from('test').pk('id', v.string(), () => 'x').build()
+			const _ref = repo.on(_TestSchema)
+
+			expectTypeOf(_ref.raw).parameters.toEqualTypeOf<[command: string, params?: unknown[]]>()
+		})
+
+		test('type-level: per-call <T> override narrows PG raw return type', async () => {
+			const { Repo } = await import('../../repo/repo')
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const { adapter } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			const repo = Repo.from(adapter).resolve(() => ({ table: 'test' })).build()
+			const _TestSchema = Schema.from('test').pk('id', v.string(), () => 'x').build()
+			const _ref = repo.on(_TestSchema)
+
+			expectTypeOf(_ref.raw<{ id: string }[]>).returns.toEqualTypeOf<Promise<{ id: string }[]>>()
 		})
 
 		test('nested session returns callback without starting new transaction', () => {

--- a/src/orm/adapters/postgresql/index.ts
+++ b/src/orm/adapters/postgresql/index.ts
@@ -432,6 +432,51 @@ if (import.meta.vitest) {
 			expectTypeOf(_ref.raw<{ id: string }[]>).returns.toEqualTypeOf<Promise<{ id: string }[]>>()
 		})
 
+		test('raw forwards (command, params) to pool.query at runtime', async () => {
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const schema = Schema.from('pg_raw').pk('id', v.string(), () => 'x').build()
+			const { adapter, pool } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			let capturedCommand: unknown
+			let capturedParams: unknown
+			const mockResult = { rows: [{ id: '1' }], rowCount: 1 }
+			;(pool as any).query = async (cmd: unknown, params: unknown) => {
+				capturedCommand = cmd
+				capturedParams = params
+				return mockResult
+			}
+			const result = await adapter.use(schema, { table: 'users' }).raw('SELECT * FROM users WHERE id = $1', ['abc'])
+			expect(capturedCommand).toBe('SELECT * FROM users WHERE id = $1')
+			expect(capturedParams).toEqual(['abc'])
+			expect(result).toBe(mockResult)
+		})
+
+		test('raw defaults params to [] when omitted', async () => {
+			const { Schema } = await import('../../schema')
+			const { v } = await import('valleyed')
+			const schema = Schema.from('pg_raw2').pk('id', v.string(), () => 'x').build()
+			const { adapter, pool } = createPostgresAdapter({
+				host: 'localhost',
+				port: 5432,
+				username: 'test',
+				password: 'test',
+				database: 'testdb',
+			})
+			let capturedParams: unknown
+			;(pool as any).query = async (_cmd: unknown, params: unknown) => {
+				capturedParams = params
+				return { rows: [] }
+			}
+			await adapter.use(schema, { table: 'users' }).raw('SELECT 1')
+			expect(capturedParams).toEqual([])
+		})
+
 		test('nested session returns callback without starting new transaction', () => {
 			const { adapter } = createPostgresAdapter({
 				host: 'localhost',

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -1,3 +1,4 @@
+import type { InferRawArgs, InferRawReturn } from '../adapter'
 import type { OrmUse } from '../adapters/base'
 import type { AnyField } from '../fields'
 import { FilterGroup, type FilterFactory } from '../filter'
@@ -42,8 +43,10 @@ export type AllBuilderSurface<S extends AnySchema, A = unknown, Sel extends stri
 	(HasMethod<A, 'queryable', 'deleteMany'> extends true ? {} : { delete: never })
 
 export type SchemaRefSurface<S extends AnySchema, A = unknown> =
-	SchemaRef<S, A> &
-	(HasMethod<A, 'crud', 'raw'> extends true ? {} : { raw: never })
+	Omit<SchemaRef<S, A>, 'raw'> &
+	(HasMethod<A, 'crud', 'raw'> extends true
+		? { raw: <T = InferRawReturn<A>>(...args: InferRawArgs<A>) => Promise<T> }
+		: { raw: never })
 
 type ReadBuilderFor<TBuilder, S extends AnySchema, A, Sel extends string, P extends readonly AnyPreloadDef[]> = TBuilder extends {
 	_builderKind: 'one'
@@ -146,8 +149,8 @@ export class SchemaRef<S extends AnySchema, A = unknown> {
 		return new AllBuilder<S, A, never, []>(this.#context) as AllBuilderSurface<S, A, never, []>
 	}
 
-	raw<T = unknown>(command: unknown, params?: unknown[]) {
-		return this.#context.use.raw<T>(command, params)
+	raw(...args: any[]) {
+		return this.#context.use.raw(...args)
 	}
 }
 

--- a/src/orm/repo/repo.ts
+++ b/src/orm/repo/repo.ts
@@ -28,7 +28,7 @@ export class Repo<A extends OrmAdapterLike<any>> {
 	}
 
 	on<S extends AnySchema>(schema: S): SchemaRefSurface<S, A> {
-		return new SchemaRef<S, A>(new SchemaContext(schema, (target) => this.#getUse(target))) as SchemaRefSurface<S, A>
+		return new SchemaRef<S, A>(new SchemaContext(schema, (target) => this.#getUse(target))) as unknown as SchemaRefSurface<S, A>
 	}
 
 	static from<NewA extends OrmAdapterLike<any>>(adapter: NewA): RepoBuilder<NewA> {
@@ -360,14 +360,63 @@ if (import.meta.vitest) {
 			expect(updated?.posts).toHaveLength(1)
 		})
 
-		test('raw operations throw EquippedError on in-memory adapter', async () => {
-			const { EquippedError } = await import('../../errors')
+		test('in-memory adapter without crud.raw collapses schemaRef.raw to never', () => {
 			const repo = makeRepo()
-			const error = await repo
-				.on(UserSchema)
-				.raw('SELECT * FROM users')
-				.catch((e) => e)
-			expect(error).toBeInstanceOf(EquippedError)
+			const ref = repo.on(UserSchema)
+			expectTypeOf(ref.raw).toBeNever()
+		})
+
+		test('raw forwards user args through adapter.use to crud.raw', async () => {
+			let capturedArgs: unknown[] = []
+			const rawAdapter = Adapter.from<{ table: string }>()
+				.supportedFieldTypes('string', 'number')
+				.queryableOps('eq')
+				.queryable({ findMany: async () => [] })
+				.crud({
+					findByPk: async () => null,
+					raw: async (_s, _c, command: string, params: unknown[]) => {
+						capturedArgs = [_s, _c, command, params]
+						return { rows: [{ id: '1' }] }
+					},
+				})
+				.build()
+			const repo = Repo.from(rawAdapter)
+				.resolve((s) => ({ table: s.name }))
+				.build()
+			const TestSchema = Schema.from('raw_test')
+				.pk('id', v.string(), () => 'x')
+				.build()
+
+			const result = await repo.on(TestSchema).raw('SELECT * FROM raw_test WHERE id = $1', ['abc'])
+			expect(capturedArgs[0]).toBe(TestSchema)
+			expect(capturedArgs[1]).toEqual({ table: 'raw_test' })
+			expect(capturedArgs[2]).toBe('SELECT * FROM raw_test WHERE id = $1')
+			expect(capturedArgs[3]).toEqual(['abc'])
+			expect(result).toEqual({ rows: [{ id: '1' }] })
+		})
+
+		test('raw with single-arg adapter (mongo-style) forwards correctly', async () => {
+			let capturedPipeline: unknown = undefined
+			const mongoStyleAdapter = Adapter.from<{ col: string }>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_s, _c, pipeline: Record<string, unknown>[]) => {
+						capturedPipeline = pipeline
+						return [{ total: 42 }]
+					},
+				})
+				.build()
+			const repo = Repo.from(mongoStyleAdapter)
+				.resolve(() => ({ col: 'test' }))
+				.build()
+			const TestSchema = Schema.from('mongo_test')
+				.pk('id', v.string(), () => 'x')
+				.build()
+
+			const result = await repo.on(TestSchema).raw([{ $count: 'total' }])
+			expect(capturedPipeline).toEqual([{ $count: 'total' }])
+			expect(result).toEqual([{ total: 42 }])
 		})
 
 		test('computed fields are derived and shaped correctly when selected', async () => {
@@ -875,9 +924,7 @@ if (import.meta.vitest) {
 				.supportedFieldTypes('string')
 				.crud({
 					findByPk: async () => null,
-					raw: async () => {
-						throw new Error('not implemented')
-					},
+					raw: async (_schema, _config, _command: string) => ({ rows: [] }),
 				})
 				.build()
 			const _repo = Repo.from(_adapter)
@@ -888,6 +935,66 @@ if (import.meta.vitest) {
 				.build()
 			const _ref = _repo.on(_TestSchema)
 			expectTypeOf(_ref.raw).toBeFunction()
+		})
+
+		test('adapter raw signature drives arg-tuple inference on schemaRef.raw', () => {
+			const _adapter = Adapter.from<{ table: string }>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_schema: import('../schema').AnySchema, _config: { table: string }, _sql: string, _params: number[]) => [42],
+				})
+				.build()
+			const _repo = Repo.from(_adapter)
+				.resolve(() => ({ table: 'test' }))
+				.build()
+			const _TestSchema = Schema.from('test')
+				.pk('id', v.string(), () => 'x')
+				.build()
+			const _ref = _repo.on(_TestSchema)
+			expectTypeOf(_ref.raw).toBeFunction()
+			expectTypeOf(_ref.raw).parameters.toEqualTypeOf<[sql: string, params: number[]]>()
+		})
+
+		test('per-call <T> override narrows raw return type', () => {
+			const _adapter = Adapter.from<{ table: string }>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_schema: import('../schema').AnySchema, _config: { table: string }, _sql: string) => ({ rows: [] as unknown[] }),
+				})
+				.build()
+			const _repo = Repo.from(_adapter)
+				.resolve(() => ({ table: 'test' }))
+				.build()
+			const _TestSchema = Schema.from('test')
+				.pk('id', v.string(), () => 'x')
+				.build()
+			const _ref = _repo.on(_TestSchema)
+			const _defaultResult = _ref.raw('SELECT 1')
+			expectTypeOf(_defaultResult).toEqualTypeOf<Promise<{ rows: unknown[] }>>()
+			const _narrowed = _ref.raw<string[]>('SELECT 1')
+			expectTypeOf(_narrowed).toEqualTypeOf<Promise<string[]>>()
+		})
+
+		test('adapter with zero-arg raw infers empty arg tuple', () => {
+			const _adapter = Adapter.from<unknown>()
+				.supportedFieldTypes('string')
+				.crud({
+					findByPk: async () => null,
+					raw: async (_schema: import('../schema').AnySchema, _config: unknown) => 'pong',
+				})
+				.build()
+			const _repo = Repo.from(_adapter)
+				.resolve(() => ({}))
+				.build()
+			const _TestSchema = Schema.from('test')
+				.pk('id', v.string(), () => 'x')
+				.build()
+			const _ref = _repo.on(_TestSchema)
+			expectTypeOf(_ref.raw).parameters.toEqualTypeOf<[]>()
+			const _result = _ref.raw()
+			expectTypeOf(_result).toEqualTypeOf<Promise<string>>()
 		})
 
 		test('gating survives through select() chains', () => {


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #33.

Closes #33

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._