### PR TITLE
refactor(instance): rewrite Instance.on as class-keyed hook DAG

### DIFF
--- a/src/audit/events.ts
+++ b/src/audit/events.ts
@@ -48,17 +48,13 @@ export class EventAudit {
 			options: { skipAudit: true },
 		})
 
-		Instance.on(
-			'start',
-			() => {
-				setInterval(async () => {
-					const queue = [...this.asyncQueue]
-					this.asyncQueue = []
-					await Promise.all(queue.map((job) => job()))
-				}, 200)
-			},
-			4,
-		)
+		Instance.on('start', () => {
+			setInterval(async () => {
+				const queue = [...this.asyncQueue]
+				this.asyncQueue = []
+				await Promise.all(queue.map((job) => job()))
+			}, 200)
+		})
 	}
 
 	async #createEvent(name: string, payload: unknown, context: Context) {

--- a/src/cache/adapters/in-memory/index.ts
+++ b/src/cache/adapters/in-memory/index.ts
@@ -18,19 +18,15 @@ export class InMemoryCache extends configurable(
 
 		constructor() {
 			super()
-			Instance.on(
-				'start',
-				async () => {
-					this.#interval = setInterval(() => {
-						const now = Date.now()
-						for (const [key, record] of this.#caches.entries()) {
-							if (record.expiredAt && record.expiredAt <= now) this.#caches.delete(key)
-						}
-					}, 5000)
-				},
-				1,
-			)
-			Instance.on('close', async () => clearInterval(this.#interval), 1)
+			Instance.on('start', async () => {
+				this.#interval = setInterval(() => {
+					const now = Date.now()
+					for (const [key, record] of this.#caches.entries()) {
+						if (record.expiredAt && record.expiredAt <= now) this.#caches.delete(key)
+					}
+				}, 5000)
+			})
+			Instance.on('close', async () => clearInterval(this.#interval))
 		}
 
 		async delete(key: string) {

--- a/src/cache/adapters/redis/index.ts
+++ b/src/cache/adapters/redis/index.ts
@@ -47,8 +47,8 @@ export class RedisCache extends configurable(
 			this.#client.on('error', async (error) => {
 				Instance.crash(new EquippedError(`Redis failed with error`, {}, error))
 			})
-			if (!extraConfig) Instance.on('start', async () => this.#client.connect(), 1)
-			Instance.on('close', async () => this.#client.quit(), 1)
+			if (!extraConfig) Instance.on('start', async () => this.#client.connect())
+			Instance.on('close', async () => this.#client.quit())
 		}
 
 		get connectionOptions () {

--- a/src/dbs/adapters/mongodb/changes.ts
+++ b/src/dbs/adapters/mongodb/changes.ts
@@ -65,38 +65,34 @@ export class MongoDbChange<Model extends core.Model<{ _id: string }>, Entity ext
 				})
 		})
 
-		Instance.on(
-			'start',
-			async () => {
-				if (this.#started) return
-				this.#started = true
+		Instance.on('start', async () => {
+			if (this.#started) return
+			this.#started = true
 
-				await retry(
-					async () => {
-						const started = await this.configureConnector(topic, {
-							'connector.class': 'io.debezium.connector.mongodb.MongoDbConnector',
-							'capture.mode': 'change_streams_update_full_with_pre_image',
-							'mongodb.connection.string': config.uri,
-							'collection.include.list': dbColName,
-							'snapshot.mode': 'when_needed',
-							'capture.scope': 'collection',
-							'capture.target': dbColName,
-							'heartbeat.interval.ms': '60000',
-							'errors.max.retries': '3',
-						})
+			await retry(
+				async () => {
+					const started = await this.configureConnector(topic, {
+						'connector.class': 'io.debezium.connector.mongodb.MongoDbConnector',
+						'capture.mode': 'change_streams_update_full_with_pre_image',
+						'mongodb.connection.string': config.uri,
+						'collection.include.list': dbColName,
+						'snapshot.mode': 'when_needed',
+						'capture.scope': 'collection',
+						'capture.target': dbColName,
+						'heartbeat.interval.ms': '60000',
+						'errors.max.retries': '3',
+					})
 
-						if (started) return { done: true, value: true }
-						await collection.findOneAndUpdate(condition, { $set: { colName } as any }, { upsert: true })
-						await collection.findOneAndDelete(condition)
-						Instance.get().log.warn(`Waiting for db changes for ${dbColName} to start...`)
-						return { done: false }
-					},
-					6,
-					30_000,
-				).catch((err) => Instance.crash(new EquippedError(`Failed to start db changes`, { dbColName }, err)))
-			},
-			10,
-		)
+					if (started) return { done: true, value: true }
+					await collection.findOneAndUpdate(condition, { $set: { colName } as any }, { upsert: true })
+					await collection.findOneAndDelete(condition)
+					Instance.get().log.warn(`Waiting for db changes for ${dbColName} to start...`)
+					return { done: false }
+				},
+				6,
+				30_000,
+			).catch((err) => Instance.crash(new EquippedError(`Failed to start db changes`, { dbColName }, err)))
+		})
 	}
 }
 

--- a/src/dbs/adapters/mongodb/db.ts
+++ b/src/dbs/adapters/mongodb/db.ts
@@ -38,39 +38,35 @@ export class MongoDb extends Db<{ _id: string }> {
 		super(dbConfig)
 		this.mongoConfig = v.assert(mongoDbConfigPipe(), mongoConfig)
 		this.client = new MongoClient(mongoConfig.uri, { ignoreUndefined: true })
-		Instance.on(
-			'start',
-			async () => {
-				await this.client.connect()
+		Instance.on('start', async () => {
+			await this.client.connect()
 
-				const grouped = this.#cols.reduce<Record<string, string[]>>((acc, cur) => {
-					if (!acc[cur.db]) acc[cur.db] = []
-					acc[cur.db].push(cur.col)
-					return acc
-				}, {})
+			const grouped = this.#cols.reduce<Record<string, string[]>>((acc, cur) => {
+				if (!acc[cur.db]) acc[cur.db] = []
+				acc[cur.db].push(cur.col)
+				return acc
+			}, {})
 
-				const options = {
-					changeStreamPreAndPostImages: { enabled: true },
-				}
-				await Promise.all(
-					Object.entries(grouped).map(async ([dbName, colNames]) => {
-						const db = this.client.db(dbName)
-						const collections = await db.listCollections<CollectionInfo>().toArray()
-						return colNames.map(async (colName) => {
-							const existing = collections.find((collection) => collection.name === colName)
-							if (existing) {
-								if (
-									existing.options?.changeStreamPreAndPostImages?.enabled !== options.changeStreamPreAndPostImages.enabled
-								)
-									await db.command({ collMod: colName, ...options })
-							} else await db.createCollection(colName, options)
-						})
-					}),
-				)
-			},
-			3,
-		)
-		Instance.on('close', async () => this.client.close(), 1)
+			const options = {
+				changeStreamPreAndPostImages: { enabled: true },
+			}
+			await Promise.all(
+				Object.entries(grouped).map(async ([dbName, colNames]) => {
+					const db = this.client.db(dbName)
+					const collections = await db.listCollections<CollectionInfo>().toArray()
+					return colNames.map(async (colName) => {
+						const existing = collections.find((collection) => collection.name === colName)
+						if (existing) {
+							if (
+								existing.options?.changeStreamPreAndPostImages?.enabled !== options.changeStreamPreAndPostImages.enabled
+							)
+								await db.command({ collMod: colName, ...options })
+						} else await db.createCollection(colName, options)
+					})
+				}),
+			)
+		})
+		Instance.on('close', async () => this.client.close())
 	}
 
 	async session<T>(callback: () => Promise<T>) {

--- a/src/events/adapters/kafka/index.ts
+++ b/src/events/adapters/kafka/index.ts
@@ -92,16 +92,12 @@ export class KafkaEventBus extends configurable(
 						})
 
 						if (options.fanout)
-							Instance.on(
-								'close',
-								async () => {
-									await consumer.disconnect()
-									await this.#deleteGroup(groupId)
-								},
-								10,
-							)
+							Instance.on('close', async () => {
+								await consumer.disconnect()
+								await this.#deleteGroup(groupId)
+							})
 					}
-					Instance.on('start', subscribe, 2)
+					Instance.on('start', subscribe)
 				},
 			}
 		}

--- a/src/events/adapters/rabbitmq/index.ts
+++ b/src/events/adapters/rabbitmq/index.ts
@@ -65,7 +65,7 @@ export class RabbitMQEventBus extends configurable(
 						})
 					}
 
-					Instance.on('start', subscribe, 2)
+					Instance.on('start', subscribe)
 				},
 			}
 		}

--- a/src/instance/hooks.ts
+++ b/src/instance/hooks.ts
@@ -1,25 +1,184 @@
 export type HookEvent = 'setup' | 'start' | 'close'
 export type HookCb = Promise<unknown | void> | (() => void | unknown | Promise<void | unknown>)
-export type HookRecord = { cb: HookCb; order: number }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ClassRef = abstract new (...args: any[]) => any
+export type HookOptions = {
+	class?: ClassRef
+	after?: ClassRef[]
+}
+export type HookRecord = { cb: HookCb; class?: ClassRef; after: ClassRef[] }
+
+export function registerHook(hooks: HookRecord[], record: HookRecord): void {
+	for (const dep of record.after) {
+		if (!hooks.some((h) => h.class === dep)) {
+			const depName = dep.name || 'unknown'
+			const ownerName = record.class?.name || 'anonymous'
+			throw new Error(`Missing dependency: ${ownerName} declares after: [${depName}], but ${depName} is not registered`)
+		}
+	}
+
+	if (record.class) {
+		const tentative = [...hooks, record]
+		detectCycle(tentative)
+	}
+
+	hooks.push(record)
+}
+
+function detectCycle(hooks: HookRecord[]): void {
+	const classToAfter = new Map<ClassRef, ClassRef[]>()
+	for (const h of hooks) {
+		if (!h.class) continue
+		const existing = classToAfter.get(h.class)
+		if (existing) {
+			for (const dep of h.after) {
+				if (!existing.includes(dep)) existing.push(dep)
+			}
+		} else {
+			classToAfter.set(h.class, [...h.after])
+		}
+	}
+
+	const visited = new Set<ClassRef>()
+	const stack = new Set<ClassRef>()
+
+	function visit(cls: ClassRef, path: ClassRef[]): void {
+		if (stack.has(cls)) {
+			const cycleStart = path.indexOf(cls)
+			const cycle = [...path.slice(cycleStart), cls]
+			const names = cycle.map((c) => c.name || 'unknown')
+			throw new Error(`Cycle detected: ${names.join(' → ')}`)
+		}
+		if (visited.has(cls)) return
+		stack.add(cls)
+		path.push(cls)
+		for (const dep of classToAfter.get(cls) ?? []) {
+			visit(dep, path)
+		}
+		path.pop()
+		stack.delete(cls)
+		visited.add(cls)
+	}
+
+	for (const cls of classToAfter.keys()) {
+		visit(cls, [])
+	}
+}
+
+export type HookLayer = HookRecord[]
+
+export function resolveHookDAG(hooks: HookRecord[], invert: boolean = false): HookLayer[] {
+	if (hooks.length === 0) return []
+
+	const classToHooks = new Map<ClassRef, HookRecord[]>()
+	const anonymous: HookRecord[] = []
+
+	for (const h of hooks) {
+		if (h.class) {
+			const list = classToHooks.get(h.class)
+			if (list) list.push(h)
+			else classToHooks.set(h.class, [h])
+		} else {
+			anonymous.push(h)
+		}
+	}
+
+	const classes = [...classToHooks.keys()]
+
+	const inDegree = new Map<ClassRef, number>()
+	const graph = new Map<ClassRef, ClassRef[]>()
+
+	for (const cls of classes) {
+		inDegree.set(cls, 0)
+		graph.set(cls, [])
+	}
+
+	for (const h of hooks) {
+		if (!h.class) continue
+		for (const dep of h.after) {
+			if (!invert) {
+				const edges = graph.get(dep)!
+				if (!edges.includes(h.class)) {
+					edges.push(h.class)
+					inDegree.set(h.class, (inDegree.get(h.class) ?? 0) + 1)
+				}
+			} else {
+				const edges = graph.get(h.class)
+				if (!edges) continue
+				if (!edges.includes(dep)) {
+					edges.push(dep)
+					inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1)
+				}
+			}
+		}
+	}
+
+	const layers: HookLayer[] = []
+	let queue = classes.filter((c) => inDegree.get(c) === 0)
+
+	while (queue.length > 0) {
+		const layer: HookRecord[] = []
+		const next: ClassRef[] = []
+
+		for (const cls of queue) {
+			layer.push(...(classToHooks.get(cls) ?? []))
+		}
+		layers.push(layer)
+
+		for (const cls of queue) {
+			for (const neighbor of graph.get(cls) ?? []) {
+				const d = inDegree.get(neighbor)! - 1
+				inDegree.set(neighbor, d)
+				if (d === 0) next.push(neighbor)
+			}
+		}
+
+		queue = next
+	}
+
+	if (anonymous.length > 0) {
+		const anonWithDeps = anonymous.filter((h) => h.after.length > 0)
+		const anonWithoutDeps = anonymous.filter((h) => h.after.length === 0)
+
+		if (anonWithDeps.length > 0) {
+			let maxLayer = -1
+			for (const h of anonWithDeps) {
+				for (const dep of h.after) {
+					const depLayer = layers.findIndex((l) => l.some((r) => r.class === dep))
+					if (depLayer > maxLayer) maxLayer = depLayer
+				}
+			}
+			const insertAt = maxLayer + 1
+			if (insertAt < layers.length) {
+				layers[insertAt].push(...anonWithDeps)
+			} else {
+				layers.push(anonWithDeps)
+			}
+		}
+
+		if (anonWithoutDeps.length > 0) {
+			if (layers.length > 0) {
+				layers[layers.length - 1].push(...anonWithoutDeps)
+			} else {
+				layers.push(anonWithoutDeps)
+			}
+		}
+	}
+
+	return layers
+}
 
 export async function runHooks(
 	hooks: HookRecord[],
 	onError: (error: Error) => void = (error) => {
 		throw error
 	},
+	invert: boolean = false,
 ) {
-	const grouped = hooks.reduce<Record<string, HookRecord[]>>((acc, cur) => {
-		const key = cur.order.toString()
-		if (!acc[key]) acc[key] = []
-		acc[key].push(cur)
-		return acc
-	}, {})
-	const groups = Object.keys(grouped)
-		.sort((a, b) => parseInt(a) - parseInt(b))
-		.map((key) => grouped[key])
-	for (const group of groups)
+	const layers = resolveHookDAG(hooks, invert)
+	for (const layer of layers)
 		await Promise.all(
-			group.map(async (h) => {
+			layer.map(async (h) => {
 				try {
 					if (typeof h.cb === 'function') return await h.cb()
 					return await h.cb
@@ -28,4 +187,277 @@ export async function runHooks(
 				}
 			}),
 		)
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect } = import.meta.vitest
+
+	class A {}
+	class B {}
+	class C {}
+	class D {}
+
+	const noop = () => {}
+
+	describe('registerHook', () => {
+		test('registers a hook with no dependencies', () => {
+			const hooks: HookRecord[] = []
+			registerHook(hooks, { cb: noop, class: A, after: [] })
+			expect(hooks).toHaveLength(1)
+		})
+
+		test('throws on missing dependency', () => {
+			const hooks: HookRecord[] = []
+			expect(() => registerHook(hooks, { cb: noop, class: B, after: [A] })).toThrow(/Missing dependency.*B.*A/)
+		})
+
+		test('throws on cycle: A→B→A', () => {
+			const hooks: HookRecord[] = []
+			registerHook(hooks, { cb: noop, class: A, after: [] })
+			registerHook(hooks, { cb: noop, class: B, after: [A] })
+			expect(() => registerHook(hooks, { cb: noop, class: A, after: [B] })).toThrow(/Cycle detected/)
+		})
+
+		test('throws on transitive cycle: A→B→C→A', () => {
+			const hooks: HookRecord[] = []
+			registerHook(hooks, { cb: noop, class: A, after: [] })
+			registerHook(hooks, { cb: noop, class: B, after: [A] })
+			registerHook(hooks, { cb: noop, class: C, after: [B] })
+			expect(() => registerHook(hooks, { cb: noop, class: A, after: [C] })).toThrow(/Cycle detected/)
+		})
+
+		test('allows anonymous hooks with dependencies', () => {
+			const hooks: HookRecord[] = []
+			registerHook(hooks, { cb: noop, class: A, after: [] })
+			registerHook(hooks, { cb: noop, after: [A] })
+			expect(hooks).toHaveLength(2)
+		})
+
+		test('anonymous hook throws on missing dependency', () => {
+			const hooks: HookRecord[] = []
+			expect(() => registerHook(hooks, { cb: noop, after: [A] })).toThrow(/Missing dependency.*anonymous.*A/)
+		})
+	})
+
+	describe('resolveHookDAG', () => {
+		test('linear chain: A → B → C', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [B] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(3)
+			expect(layers[0].every((h) => h.class === A)).toBe(true)
+			expect(layers[1].every((h) => h.class === B)).toBe(true)
+			expect(layers[2].every((h) => h.class === C)).toBe(true)
+		})
+
+		test('fan-out: A → B, A → C (B and C are parallel)', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [A] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(2)
+			expect(layers[0].every((h) => h.class === A)).toBe(true)
+			const secondClasses = layers[1].map((h) => h.class)
+			expect(secondClasses).toContain(B)
+			expect(secondClasses).toContain(C)
+		})
+
+		test('fan-in: B → D, C → D', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: B, after: [] },
+				{ cb: noop, class: C, after: [] },
+				{ cb: noop, class: D, after: [B, C] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(2)
+			const firstClasses = layers[0].map((h) => h.class)
+			expect(firstClasses).toContain(B)
+			expect(firstClasses).toContain(C)
+			expect(layers[1].every((h) => h.class === D)).toBe(true)
+		})
+
+		test('diamond: A → B, A → C, B → D, C → D', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [A] },
+				{ cb: noop, class: D, after: [B, C] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(3)
+			expect(layers[0][0].class).toBe(A)
+			const midClasses = layers[1].map((h) => h.class)
+			expect(midClasses).toContain(B)
+			expect(midClasses).toContain(C)
+			expect(layers[2][0].class).toBe(D)
+		})
+
+		test('close-event inversion reverses the graph', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [B] },
+			]
+			const layers = resolveHookDAG(hooks, true)
+			expect(layers).toHaveLength(3)
+			expect(layers[0].every((h) => h.class === C)).toBe(true)
+			expect(layers[1].every((h) => h.class === B)).toBe(true)
+			expect(layers[2].every((h) => h.class === A)).toBe(true)
+		})
+
+		test('close inversion: fan-out becomes fan-in', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [A] },
+			]
+			const layers = resolveHookDAG(hooks, true)
+			expect(layers).toHaveLength(2)
+			const firstClasses = layers[0].map((h) => h.class)
+			expect(firstClasses).toContain(B)
+			expect(firstClasses).toContain(C)
+			expect(layers[1].every((h) => h.class === A)).toBe(true)
+		})
+
+		test('multiple hooks per class are all in the same layer', () => {
+			const cb1 = () => {}
+			const cb2 = () => {}
+			const hooks: HookRecord[] = [
+				{ cb: cb1, class: A, after: [] },
+				{ cb: cb2, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(2)
+			expect(layers[0]).toHaveLength(2)
+			expect(layers[0].every((h) => h.class === A)).toBe(true)
+		})
+
+		test('anonymous hooks without deps run at deepest level', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, after: [] },
+			]
+			const layers = resolveHookDAG(hooks)
+			expect(layers).toHaveLength(2)
+			const lastLayer = layers[layers.length - 1]
+			expect(lastLayer.some((h) => h.class === undefined)).toBe(true)
+		})
+
+		test('anonymous hooks with deps run after their dependencies', () => {
+			const hooks: HookRecord[] = [
+				{ cb: noop, class: A, after: [] },
+				{ cb: noop, class: B, after: [A] },
+				{ cb: noop, class: C, after: [B] },
+				{ cb: noop, after: [A] },
+			]
+			const layers = resolveHookDAG(hooks)
+			const anonLayer = layers.findIndex((l) => l.some((h) => h.class === undefined))
+			const aLayer = layers.findIndex((l) => l.some((h) => h.class === A))
+			expect(anonLayer).toBeGreaterThan(aLayer)
+		})
+
+		test('empty hooks returns empty layers', () => {
+			expect(resolveHookDAG([])).toEqual([])
+		})
+	})
+
+	describe('runHooks', () => {
+		test('same-depth siblings observably overlap', async () => {
+			const log: string[] = []
+			const hooks: HookRecord[] = [
+				{
+					cb: async () => {
+						log.push('B-start')
+						await new Promise((r) => setTimeout(r, 20))
+						log.push('B-end')
+					},
+					class: B,
+					after: [],
+				},
+				{
+					cb: async () => {
+						log.push('C-start')
+						await new Promise((r) => setTimeout(r, 20))
+						log.push('C-end')
+					},
+					class: C,
+					after: [],
+				},
+			]
+			await runHooks(hooks)
+			expect(log[0]).toBe('B-start')
+			expect(log[1]).toBe('C-start')
+		})
+
+		test('different depths run sequentially', async () => {
+			const log: string[] = []
+			const hooks: HookRecord[] = [
+				{
+					cb: async () => {
+						log.push('A')
+					},
+					class: A,
+					after: [],
+				},
+				{
+					cb: async () => {
+						log.push('B')
+					},
+					class: B,
+					after: [A],
+				},
+			]
+			await runHooks(hooks)
+			expect(log).toEqual(['A', 'B'])
+		})
+
+		test('close inversion runs hooks in reverse dependency order', async () => {
+			const log: string[] = []
+			const hooks: HookRecord[] = [
+				{ cb: async () => log.push('A'), class: A, after: [] },
+				{ cb: async () => log.push('B'), class: B, after: [A] },
+				{ cb: async () => log.push('C'), class: C, after: [B] },
+			]
+			await runHooks(hooks, undefined, true)
+			expect(log).toEqual(['C', 'B', 'A'])
+		})
+
+		test('errors are routed to onError handler', async () => {
+			const errors: Error[] = []
+			const hooks: HookRecord[] = [
+				{
+					cb: () => {
+						throw new Error('boom')
+					},
+					class: A,
+					after: [],
+				},
+			]
+			await runHooks(hooks, (e) => {
+				errors.push(e)
+			})
+			expect(errors).toHaveLength(1)
+			expect(errors[0].message).toBe('boom')
+		})
+
+		test('raw promise callbacks are awaited', async () => {
+			const log: string[] = []
+			const hooks: HookRecord[] = [
+				{
+					cb: Promise.resolve().then(() => log.push('resolved')),
+					class: A,
+					after: [],
+				},
+			]
+			await runHooks(hooks)
+			expect(log).toContain('resolved')
+		})
+	})
 }

--- a/src/instance/hooks.ts
+++ b/src/instance/hooks.ts
@@ -1,6 +1,6 @@
 export type HookEvent = 'setup' | 'start' | 'close'
 export type HookCb = Promise<unknown | void> | (() => void | unknown | Promise<void | unknown>)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export type ClassRef = abstract new (...args: any[]) => any
 export type HookOptions = {
 	class?: ClassRef
@@ -96,19 +96,11 @@ export function resolveHookDAG(hooks: HookRecord[], invert: boolean = false): Ho
 	for (const h of hooks) {
 		if (!h.class) continue
 		for (const dep of h.after) {
-			if (!invert) {
-				const edges = graph.get(dep)!
-				if (!edges.includes(h.class)) {
-					edges.push(h.class)
-					inDegree.set(h.class, (inDegree.get(h.class) ?? 0) + 1)
-				}
-			} else {
-				const edges = graph.get(h.class)
-				if (!edges) continue
-				if (!edges.includes(dep)) {
-					edges.push(dep)
-					inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1)
-				}
+			const [from, to] = invert ? [h.class, dep] : [dep, h.class]
+			const edges = graph.get(from)!
+			if (!edges.includes(to)) {
+				edges.push(to)
+				inDegree.set(to, inDegree.get(to)! + 1)
 			}
 		}
 	}

--- a/src/instance/index.ts
+++ b/src/instance/index.ts
@@ -3,8 +3,10 @@ import { ulid } from 'ulid'
 import { type Pipe, v } from 'valleyed'
 
 import { EquippedError } from '../errors'
-import { type HookCb, type HookEvent, type HookRecord, runHooks } from './hooks'
+import { type ClassRef, type HookCb, type HookEvent, type HookOptions, type HookRecord, registerHook, runHooks } from './hooks'
 import { instanceSettingsPipe, type Settings, type SettingsInput } from './settings'
+
+export type { ClassRef, HookCb, HookEvent, HookOptions }
 
 export class Instance {
 	static #id: string | undefined
@@ -87,9 +89,10 @@ export class Instance {
 		return Instance.#instance
 	}
 
-	static on(event: HookEvent, cb: HookCb, order: number) {
+	static on(event: HookEvent, cb: HookCb, options?: HookOptions) {
 		Instance.#hooks[event] ??= []
-		Instance.#hooks[event].push({ cb, order })
+		const record: HookRecord = { cb, class: options?.class, after: options?.after ?? [] }
+		registerHook(Instance.#hooks[event], record)
 	}
 
 	static #registerOnExitHandler() {
@@ -101,7 +104,7 @@ export class Instance {
 
 		Object.entries(signals).forEach(([signal, code]) => {
 			process.on(signal, async () => {
-				await runHooks(Instance.#hooks['close'] ?? [], () => {})
+				await runHooks(Instance.#hooks['close'] ?? [], () => {}, true)
 				process.exit(128 + code)
 			})
 		})
@@ -109,7 +112,7 @@ export class Instance {
 
 	static resolveBeforeCrash<T>(cb: () => Promise<T>) {
 		const value = cb()
-		Instance.on('close', async () => await value, 10)
+		Instance.on('close', async () => await value)
 		return value
 	}
 

--- a/src/jobs/adapters/redis/index.ts
+++ b/src/jobs/adapters/redis/index.ts
@@ -44,15 +44,11 @@ export class RedisJob extends configurable(
 				{ connection: redisCache.connectionOptions, autorun: false, skipVersionCheck: true },
 			)
 
-			Instance.on(
-				'start',
-				async () => {
-					await this.#cleanup()
-					await Promise.all(this.crons.map(({ cron, name }) => this.#addCron(name, cron)))
-					worker.run()
-				},
-				10,
-			)
+			Instance.on('start', async () => {
+				await this.#cleanup()
+				await Promise.all(this.crons.map(({ cron, name }) => this.#addCron(name, cron)))
+				worker.run()
+			})
 		}
 
 		#getNewId() {

--- a/src/server/adapters/express/index.ts
+++ b/src/server/adapters/express/index.ts
@@ -76,7 +76,7 @@ export const ExpressServer = configurableFn(serverConfigPipe, (config): Server =
 			new Promise((resolve: (s: boolean) => void, reject: (e: Error) => void) => {
 				try {
 					const app = httpServer.listen({ host: '0.0.0.0', port }, async () => resolve(true))
-					Instance.on('close', app.close, 1)
+					Instance.on('close', app.close)
 				} catch (err) {
 					reject(<Error>err)
 				}

--- a/src/server/adapters/fastify/index.ts
+++ b/src/server/adapters/fastify/index.ts
@@ -70,7 +70,7 @@ export const FastifyServer = configurableFn(serverConfigPipe, (config): Server =
 		start: async (port) => {
 			await app.ready()
 			await app.listen({ port, host: '0.0.0.0' })
-			Instance.on('close', app.close, 1)
+			Instance.on('close', app.close)
 			return true
 		},
 	})

--- a/src/server/sockets.ts
+++ b/src/server/sockets.ts
@@ -43,21 +43,17 @@ export class SocketEmitter {
 	) {
 		this.socketInstance = socket
 		this.#setupSocketConnection()
-		Instance.on(
-			'setup',
-			() => {
-				const stream = config.eventBus?.stream(EmitterEvent as never, { fanout: true })
-				this.#publish = stream
-					? (stream.publish as unknown as (data: EmitData) => Promise<void>)
-					: async (data: EmitData) => {
-							socket.to(data.channel).emit(data.channel, data)
-						}
-				stream?.subscribe(async (data: EmitData) => {
-					socket.to(data.channel).emit(data.channel, data)
-				})
-			},
-			1,
-		)
+		Instance.on('setup', () => {
+			const stream = config.eventBus?.stream(EmitterEvent as never, { fanout: true })
+			this.#publish = stream
+				? (stream.publish as unknown as (data: EmitData) => Promise<void>)
+				: async (data: EmitData) => {
+						socket.to(data.channel).emit(data.channel, data)
+					}
+			stream?.subscribe(async (data: EmitData) => {
+				socket.to(data.channel).emit(data.channel, data)
+			})
+		})
 	}
 
 	async created<T extends Entity>(channels: string[], data: T, to: string | string[] | null) {


### PR DESCRIPTION
RALPH: PRD #27, issue #43

Replace numeric `order` parameter with `{ class?: ClassRef; after?: ClassRef[] }` options object. Hooks now form a DAG keyed by class identity instead of using arbitrary numeric ordering.

Key decisions:
- Hook DAG resolver extracted as pure function `resolveHookDAG` for unit testing — no Instance singleton dependence
- `registerHook` validates at registration time: throws on missing dependencies and cycles with descriptive error messages
- Topo sort produces layered execution plan; same-depth siblings run in `Promise.all`; different depths run sequentially
- Close event auto-inverts the dependency graph via `invert` parameter
- Anonymous hooks (no `class:`) run at the deepest level by default; may declare `after:` to constrain themselves
- Multiple hooks per class are grouped into the same layer
- `resolveBeforeCrash` registers an anonymous close hook (no class)
- All existing callers migrated from numeric order to no-options form; semantic `class`/`after` wiring deferred to per-subsystem slices

21 Vitest tests cover: topo sort correctness on linear/fan-in/fan-out/ diamond shapes, parallel overlap, cycle detection, missing-dependency detection, close-event inversion, multiple hooks per class, anonymous hooks, raw promise callbacks, and error routing.

Files changed:
- src/instance/hooks.ts (DAG types, registerHook, resolveHookDAG, tests)
- src/instance/index.ts (Instance.on signature, resolveBeforeCrash, exports)
- src/audit/events.ts (drop numeric order)
- src/cache/adapters/in-memory/index.ts (drop numeric order)
- src/cache/adapters/redis/index.ts (drop numeric order)
- src/dbs/adapters/mongodb/changes.ts (drop numeric order)
- src/dbs/adapters/mongodb/db.ts (drop numeric order)
- src/events/adapters/kafka/index.ts (drop numeric order)
- src/events/adapters/rabbitmq/index.ts (drop numeric order)
- src/jobs/adapters/redis/index.ts (drop numeric order)
- src/server/adapters/express/index.ts (drop numeric order)
- src/server/adapters/fastify/index.ts (drop numeric order)
- src/server/sockets.ts (drop numeric order)