### PR TITLE
refactor(orm): convert all builders to clone-on-step

### DIFF
--- a/src/orm/filter.ts
+++ b/src/orm/filter.ts
@@ -22,92 +22,91 @@ export type FilterFactory = (q: FilterGroup) => FilterGroup
 export type FilterGroupOp = 'and' | 'or'
 
 export class FilterGroup {
-	readonly children: FilterChild[] = []
+	readonly children: readonly FilterChild[]
 
-	private constructor(readonly op: FilterGroupOp = 'and') {}
-
-	#addFilter(field: string | AnyField, condition: FilterOpName, value: unknown): this {
-		this.children.push(new Filter(field, condition, value))
-		return this
+	private constructor(
+		readonly op: FilterGroupOp = 'and',
+		children?: readonly FilterChild[],
+	) {
+		this.children = children ?? []
 	}
 
-	eq<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'eq', value)
+	#withChild(child: FilterChild): FilterGroup {
+		return new FilterGroup(this.op, [...this.children, child])
 	}
 
-	ne<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'ne', value)
+	eq<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'eq', value))
 	}
 
-	gt<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'gt', value)
+	ne<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'ne', value))
 	}
 
-	gte<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'gte', value)
+	gt<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'gt', value))
 	}
 
-	lt<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'lt', value)
+	gte<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'gte', value))
 	}
 
-	lte<T>(field: string | Field<T>, value: T): this {
-		return this.#addFilter(field, 'lte', value)
+	lt<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'lt', value))
 	}
 
-	in<T>(field: string | Field<T>, value: T[]): this {
-		return this.#addFilter(field, 'in', value)
+	lte<T>(field: string | Field<T>, value: T): FilterGroup {
+		return this.#withChild(new Filter(field, 'lte', value))
 	}
 
-	notIn<T>(field: string | Field<T>, value: T[]): this {
-		return this.#addFilter(field, 'notIn', value)
+	in<T>(field: string | Field<T>, value: T[]): FilterGroup {
+		return this.#withChild(new Filter(field, 'in', value))
 	}
 
-	like(field: string | Field<string>, value: string): this {
-		return this.#addFilter(field, 'like', value)
+	notIn<T>(field: string | Field<T>, value: T[]): FilterGroup {
+		return this.#withChild(new Filter(field, 'notIn', value))
 	}
 
-	exists(field: string | Field<unknown>): this {
-		return this.#addFilter(field, 'exists', true)
+	like(field: string | Field<string>, value: string): FilterGroup {
+		return this.#withChild(new Filter(field, 'like', value))
 	}
 
-	notExists(field: string | Field<unknown>): this {
-		return this.#addFilter(field, 'notExists', true)
+	exists(field: string | Field<unknown>): FilterGroup {
+		return this.#withChild(new Filter(field, 'exists', true))
 	}
 
-	contains<T>(field: string | Field<T>, value: T[]): this {
-		return this.#addFilter(field, 'contains', value)
+	notExists(field: string | Field<unknown>): FilterGroup {
+		return this.#withChild(new Filter(field, 'notExists', true))
 	}
 
-	notContains<T>(field: string | Field<T>, value: T[]): this {
-		return this.#addFilter(field, 'notContains', value)
+	contains<T>(field: string | Field<T>, value: T[]): FilterGroup {
+		return this.#withChild(new Filter(field, 'contains', value))
 	}
 
-	and(facFns: FilterFactory[]): this {
+	notContains<T>(field: string | Field<T>, value: T[]): FilterGroup {
+		return this.#withChild(new Filter(field, 'notContains', value))
+	}
+
+	and(facFns: FilterFactory[]): FilterGroup {
 		if (facFns.length === 0) throw new EquippedError('and() requires at least one filter factory', { op: 'and' })
-		const group = new FilterGroup('and')
-		group.children.push(...facFns.map((fn) => fn(new FilterGroup())))
-		this.children.push(group)
-		return this
+		const group = new FilterGroup('and', facFns.map((fn) => fn(FilterGroup.create())))
+		return this.#withChild(group)
 	}
 
-	or(facFns: FilterFactory[]): this {
+	or(facFns: FilterFactory[]): FilterGroup {
 		if (facFns.length === 0) throw new EquippedError('or() requires at least one filter factory', { op: 'or' })
-		const group = new FilterGroup('or')
-		group.children.push(...facFns.map((fn) => fn(new FilterGroup())))
-		this.children.push(group)
-		return this
+		const group = new FilterGroup('or', facFns.map((fn) => fn(FilterGroup.create())))
+		return this.#withChild(group)
 	}
 
 	clone(): FilterGroup {
-		const out = new FilterGroup(this.op)
-		out.children.push(
-			...this.children.map((c) => {
+		return new FilterGroup(
+			this.op,
+			this.children.map((c) => {
 				if (c instanceof Filter) return new Filter(c.field, c.op, structuredClone(c.value))
 				return c.clone()
 			}),
 		)
-		return out
 	}
 
 	static create(): FilterGroup {
@@ -118,7 +117,7 @@ export class FilterGroup {
 
 export type GatedFilterGroup<DeclaredOps extends readonly FilterOpName[]> = {
 	[K in FilterOpName]: K extends DeclaredOps[number] ? FilterGroup[K] : never
-} & Pick<FilterGroup, 'and' | 'or' | 'clone' | 'children' | 'op'>
+} & Pick<FilterGroup, 'and' | 'or' | 'clone' | 'op'> & { readonly children: readonly FilterChild[] }
 
 export type GatedFilterFactory<DeclaredOps extends readonly FilterOpName[]> = (
 	q: GatedFilterGroup<DeclaredOps>,
@@ -335,6 +334,42 @@ if (import.meta.vitest) {
 				expect((original.children[0] as Filter).value).toEqual([1, 2, 3])
 				expect(clonedValue).toEqual([1, 2, 3, 4])
 			})
+		})
+	})
+
+	describe('clone-on-step: fan-out independence', () => {
+		test('.eq() returns a new FilterGroup, not the same instance', () => {
+			const base = FilterGroup.create()
+			const a = base.eq('name', 'Alice')
+			expect(a).not.toBe(base)
+		})
+
+		test('fan-out from shared base does not pollute either branch', () => {
+			const base = FilterGroup.create().eq('name', 'Alice')
+			const branchA = base.gt('age', 20)
+			const branchB = base.lt('age', 40)
+
+			expect(branchA.children).toHaveLength(2)
+			expect(branchB.children).toHaveLength(2)
+			expect(base.children).toHaveLength(1)
+			expect((branchA.children[1] as Filter).op).toBe('gt')
+			expect((branchB.children[1] as Filter).op).toBe('lt')
+		})
+
+		test('.and() returns a new FilterGroup', () => {
+			const base = FilterGroup.create().eq('name', 'Alice')
+			const withAnd = base.and([(q) => q.gt('age', 20)])
+			expect(withAnd).not.toBe(base)
+			expect(base.children).toHaveLength(1)
+			expect(withAnd.children).toHaveLength(2)
+		})
+
+		test('.or() returns a new FilterGroup', () => {
+			const base = FilterGroup.create().eq('name', 'Alice')
+			const withOr = base.or([(q) => q.gt('age', 20)])
+			expect(withOr).not.toBe(base)
+			expect(base.children).toHaveLength(1)
+			expect(withOr.children).toHaveLength(2)
 		})
 	})
 

--- a/src/orm/filter.ts
+++ b/src/orm/filter.ts
@@ -117,7 +117,7 @@ export class FilterGroup {
 
 export type GatedFilterGroup<DeclaredOps extends readonly FilterOpName[]> = {
 	[K in FilterOpName]: K extends DeclaredOps[number] ? FilterGroup[K] : never
-} & Pick<FilterGroup, 'and' | 'or' | 'clone' | 'op'> & { readonly children: readonly FilterChild[] }
+} & Pick<FilterGroup, 'and' | 'or' | 'clone' | 'children' | 'op'>
 
 export type GatedFilterFactory<DeclaredOps extends readonly FilterOpName[]> = (
 	q: GatedFilterGroup<DeclaredOps>,

--- a/src/orm/query.ts
+++ b/src/orm/query.ts
@@ -51,88 +51,89 @@ export type QueryOptions<Sel extends string = string> = {
 }
 
 export class QueryGroup {
-	children: FilterOp[] = []
+	readonly children: readonly FilterOp[]
 
-	private constructor(readonly op: WhereGroupOp = WhereGroupOp.and) {}
-
-	#where(field: string | AnyField, condition: WhereOp, value: unknown): this {
-		this.children.push(new Where(field, condition, value))
-		return this
+	private constructor(
+		readonly op: WhereGroupOp = WhereGroupOp.and,
+		children?: readonly FilterOp[],
+	) {
+		this.children = children ?? []
 	}
 
-	eq<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.eq, value)
+	#withChild(child: FilterOp): QueryGroup {
+		return new QueryGroup(this.op, [...this.children, child])
 	}
 
-	ne<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.ne, value)
+	eq<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.eq, value))
 	}
 
-	gt<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.gt, value)
+	ne<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.ne, value))
 	}
 
-	gte<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.gte, value)
+	gt<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.gt, value))
 	}
 
-	lt<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.lt, value)
+	gte<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.gte, value))
 	}
 
-	lte<T>(field: string | Field<T>, value: T): this {
-		return this.#where(field, WhereOp.lte, value)
+	lt<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.lt, value))
 	}
 
-	in<T>(field: string | Field<T>, value: T[]): this {
-		return this.#where(field, WhereOp.in, value)
+	lte<T>(field: string | Field<T>, value: T): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.lte, value))
 	}
 
-	nin<T>(field: string | Field<T>, value: T[]): this {
-		return this.#where(field, WhereOp.nin, value)
+	in<T>(field: string | Field<T>, value: T[]): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.in, value))
 	}
 
-	like(field: string | Field<string>, value: string): this {
-		return this.#where(field, WhereOp.like, value)
+	nin<T>(field: string | Field<T>, value: T[]): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.nin, value))
 	}
 
-	exists(field: string | Field<unknown>): this {
-		return this.#where(field, WhereOp.exists, true)
+	like(field: string | Field<string>, value: string): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.like, value))
 	}
 
-	nexists(field: string | Field<unknown>): this {
-		return this.#where(field, WhereOp.exists, false)
+	exists(field: string | Field<unknown>): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.exists, true))
 	}
 
-	contains<T>(field: string | Field<T>, value: T[]): this {
-		return this.#where(field, WhereOp.contains, value)
+	nexists(field: string | Field<unknown>): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.exists, false))
 	}
 
-	ncontains<T>(field: string | Field<T>, value: T[]): this {
-		return this.#where(field, WhereOp.ncontains, value)
+	contains<T>(field: string | Field<T>, value: T[]): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.contains, value))
 	}
 
-	and(facFns: WhereFactory[]): this {
-		const group = new QueryGroup(WhereGroupOp.and)
-		group.children = facFns.map((facFn) => facFn(new QueryGroup()))
-		this.children.push(group)
-		return this
+	ncontains<T>(field: string | Field<T>, value: T[]): QueryGroup {
+		return this.#withChild(new Where(field, WhereOp.ncontains, value))
 	}
 
-	or(facFns: WhereFactory[]): this {
-		const group = new QueryGroup(WhereGroupOp.or)
-		group.children = facFns.map((facFn) => facFn(new QueryGroup()))
-		this.children.push(group)
-		return this
+	and(facFns: WhereFactory[]): QueryGroup {
+		const group = new QueryGroup(WhereGroupOp.and, facFns.map((facFn) => facFn(QueryGroup.from())))
+		return this.#withChild(group)
+	}
+
+	or(facFns: WhereFactory[]): QueryGroup {
+		const group = new QueryGroup(WhereGroupOp.or, facFns.map((facFn) => facFn(QueryGroup.from())))
+		return this.#withChild(group)
 	}
 
 	clone(): QueryGroup {
-		const out = new QueryGroup(this.op)
-		out.children = this.children.map((c) => {
-			if (c instanceof Where) return new Where(c.field, c.op, structuredClone(c.value))
-			return c.clone()
-		})
-		return out
+		return new QueryGroup(
+			this.op,
+			this.children.map((c) => {
+				if (c instanceof Where) return new Where(c.field, c.op, structuredClone(c.value))
+				return c.clone()
+			}),
+		)
 	}
 
 	static from() {
@@ -144,6 +145,42 @@ if (import.meta.vitest) {
 	const { describe, test, expect } = import.meta.vitest
 	const { v } = await import('valleyed')
 	const { Schema } = await import('./schema')
+
+	describe('clone-on-step: fan-out independence', () => {
+		test('.eq() returns a new QueryGroup, not the same instance', () => {
+			const base = QueryGroup.from()
+			const a = base.eq('name', 'Alice')
+			expect(a).not.toBe(base)
+		})
+
+		test('fan-out from shared base does not pollute either branch', () => {
+			const base = QueryGroup.from().eq('name', 'Alice')
+			const branchA = base.gt('age', 20)
+			const branchB = base.lt('age', 40)
+
+			expect(branchA.children).toHaveLength(2)
+			expect(branchB.children).toHaveLength(2)
+			expect(base.children).toHaveLength(1)
+			expect((branchA.children[1] as Where).op).toBe(WhereOp.gt)
+			expect((branchB.children[1] as Where).op).toBe(WhereOp.lt)
+		})
+
+		test('.and() returns a new QueryGroup', () => {
+			const base = QueryGroup.from().eq('name', 'Alice')
+			const withAnd = base.and([(q) => q.gt('age', 20)])
+			expect(withAnd).not.toBe(base)
+			expect(base.children).toHaveLength(1)
+			expect(withAnd.children).toHaveLength(2)
+		})
+
+		test('.or() returns a new QueryGroup', () => {
+			const base = QueryGroup.from().eq('name', 'Alice')
+			const withOr = base.or([(q) => q.gt('age', 20)])
+			expect(withOr).not.toBe(base)
+			expect(base.children).toHaveLength(1)
+			expect(withOr.children).toHaveLength(2)
+		})
+	})
 
 	describe('query', () => {
 		test('stores clauses and nested groups', () => {

--- a/src/orm/relations.ts
+++ b/src/orm/relations.ts
@@ -80,10 +80,11 @@ export type PreloadedMap<P extends readonly AnyPreloadDef[], Depth extends reado
 
 class RelationsBuilder<S extends AnySchema, R extends Record<string, AnyRelDef> = Record<never, never>> {
 	readonly #source: S
-	readonly #defs: Record<string, AnyRelDef> = {}
+	readonly #defs: Record<string, AnyRelDef>
 
-	constructor(source: S) {
+	constructor(source: S, defs?: Record<string, AnyRelDef>) {
 		this.#source = source
+		this.#defs = defs ?? {}
 	}
 
 	hasMany<K extends string, T extends AnySchema, FK extends Field<any, any, T>>(
@@ -100,8 +101,8 @@ class RelationsBuilder<S extends AnySchema, R extends Record<string, AnyRelDef> 
 		}
 	> {
 		const target = (fk as any).__schema as AnySchema
-		this.#defs[name] = new ManyRelation(name, this.#source, target, fk as any, this.#source.pkField)
-		return this as any
+		const nextDefs = { ...this.#defs, [name]: new ManyRelation(name, this.#source, target, fk as any, this.#source.pkField) }
+		return new RelationsBuilder(this.#source, nextDefs) as any
 	}
 
 	hasOne<K extends string, T extends AnySchema, FK extends Field<any, any, T>>(
@@ -118,8 +119,8 @@ class RelationsBuilder<S extends AnySchema, R extends Record<string, AnyRelDef> 
 		}
 	> {
 		const target = (fk as any).__schema as AnySchema
-		this.#defs[name] = new OneRelation(name, this.#source, target, fk as any, 'target', this.#source.pkField)
-		return this as any
+		const nextDefs = { ...this.#defs, [name]: new OneRelation(name, this.#source, target, fk as any, 'target', this.#source.pkField) }
+		return new RelationsBuilder(this.#source, nextDefs) as any
 	}
 
 	belongsTo<K extends string, T extends AnySchema, FK extends Field<any, any, S>>(
@@ -138,8 +139,8 @@ class RelationsBuilder<S extends AnySchema, R extends Record<string, AnyRelDef> 
 		}
 	> {
 		const ref = references ?? target.pkField
-		this.#defs[name] = new OneRelation(name, this.#source, target, fk as any, 'source', ref as any)
-		return this as any
+		const nextDefs = { ...this.#defs, [name]: new OneRelation(name, this.#source, target, fk as any, 'source', ref as any) }
+		return new RelationsBuilder(this.#source, nextDefs) as any
 	}
 
 	build(): R {
@@ -201,6 +202,33 @@ if (import.meta.vitest) {
 
 			expect(rels.org.foreignKey).toBe(UserSchema.fields.orgId)
 			expect(rels.org.target).toBe(OrgSchema)
+		})
+
+		test('clone-on-step: .hasMany() returns a new builder', () => {
+			const base = Relations.from(UserSchema)
+			const a = base.hasMany('posts', PostSchema.fields.userId)
+			expect(a).not.toBe(base)
+		})
+
+		test('clone-on-step: .hasOne() returns a new builder', () => {
+			const base = Relations.from(UserSchema)
+			const a = base.hasOne('profile', ProfileSchema.fields.userId)
+			expect(a).not.toBe(base)
+		})
+
+		test('clone-on-step: .belongsTo() returns a new builder', () => {
+			const base = Relations.from(UserSchema)
+			const a = base.belongsTo('org', UserSchema.fields.orgId, OrgSchema)
+			expect(a).not.toBe(base)
+		})
+
+		test('clone-on-step: fan-out from shared base does not pollute either branch', () => {
+			const base = Relations.from(UserSchema)
+			const branchA = base.hasMany('posts', PostSchema.fields.userId).build()
+			const branchB = base.hasOne('profile', ProfileSchema.fields.userId).build()
+
+			expect(Object.keys(branchA)).toEqual(['posts'])
+			expect(Object.keys(branchB)).toEqual(['profile'])
 		})
 	})
 

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -231,53 +231,71 @@ export class OneBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 export class AllBuilder<S extends AnySchema, A = unknown, Sel extends string = never, P extends readonly AnyPreloadDef[] = []> extends ReadSelectState<S, A, Sel, P> {
 	declare readonly _builderKind: 'all'
 
-	#orderBy: OrderBy[] = []
+	#orderBy: OrderBy[]
 	#limit: number | undefined
 	#offset: number | undefined
 
+	constructor(
+		context: SchemaContext<S>,
+		state?: ReadState<Sel, P>,
+		queryState?: { orderBy?: OrderBy[]; limit?: number; offset?: number },
+	) {
+		super(context, state)
+		this.#orderBy = queryState?.orderBy ?? []
+		this.#limit = queryState?.limit
+		this.#offset = queryState?.offset
+	}
+
+	#queryState() {
+		return { orderBy: [...this.#orderBy], limit: this.#limit, offset: this.#offset }
+	}
+
 	protected _clone<NewSel extends string, NewP extends readonly AnyPreloadDef[]>(next: ReadState<NewSel, NewP>) {
-		const cloned = new AllBuilder<S, A, NewSel, NewP>(
+		return new AllBuilder<S, A, NewSel, NewP>(
 			this._context,
 			this._readState({
 				where: next.where,
 				select: next.select,
 				preloads: next.preloads,
 			}),
-		)
-		cloned.#orderBy.push(...this.#orderBy)
-		cloned.#limit = this.#limit
-		cloned.#offset = this.#offset
-		return cloned as any
+			this.#queryState(),
+		) as any
 	}
 
 	orderBy(field: string | AnyField, direction: 'asc' | 'desc' = 'asc') {
-		const cloned = this._clone<Sel, P>({
-			where: this._where.clone(),
-			select: this._select as readonly Sel[] | undefined,
-			preloads: this._preloads,
-		}) as AllBuilder<S, A, Sel, P>
-		cloned.#orderBy = this.#orderBy.concat(new OrderBy(field, direction))
-		return cloned as this
+		return new AllBuilder<S, A, Sel, P>(
+			this._context,
+			this._readState({
+				where: this._where.clone(),
+				select: this._select as readonly Sel[] | undefined,
+				preloads: this._preloads,
+			}),
+			{ orderBy: [...this.#orderBy, new OrderBy(field, direction)], limit: this.#limit, offset: this.#offset },
+		) as this
 	}
 
 	limit(limit: number) {
-		const cloned = this._clone<Sel, P>({
-			where: this._where.clone(),
-			select: this._select as readonly Sel[] | undefined,
-			preloads: this._preloads,
-		}) as AllBuilder<S, A, Sel, P>
-		cloned.#limit = limit
-		return cloned as this
+		return new AllBuilder<S, A, Sel, P>(
+			this._context,
+			this._readState({
+				where: this._where.clone(),
+				select: this._select as readonly Sel[] | undefined,
+				preloads: this._preloads,
+			}),
+			{ orderBy: [...this.#orderBy], limit, offset: this.#offset },
+		) as this
 	}
 
 	offset(offset: number) {
-		const cloned = this._clone<Sel, P>({
-			where: this._where.clone(),
-			select: this._select as readonly Sel[] | undefined,
-			preloads: this._preloads,
-		}) as AllBuilder<S, A, Sel, P>
-		cloned.#offset = offset
-		return cloned as this
+		return new AllBuilder<S, A, Sel, P>(
+			this._context,
+			this._readState({
+				where: this._where.clone(),
+				select: this._select as readonly Sel[] | undefined,
+				preloads: this._preloads,
+			}),
+			{ orderBy: [...this.#orderBy], limit: this.#limit, offset },
+		) as this
 	}
 
 	create(data: SchemaCreateInput<S>[]) {

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -102,8 +102,7 @@ abstract class ReadSelectState<S extends AnySchema, A = unknown, Sel extends str
 	}
 
 	where(factory: FilterFactory): this {
-		const nextGroup = this._where.clone()
-		factory(nextGroup)
+		const nextGroup = factory(this._where.clone())
 		return this._clone<Sel, P>({
 			where: nextGroup,
 			select: this._select as readonly Sel[] | undefined,
@@ -158,8 +157,7 @@ export class OneBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 	declare readonly _builderKind: 'one'
 
 	id(value: SchemaPrimaryKeyValue<S>): this {
-		const nextGroup = this._where.clone()
-		nextGroup.eq(this._context.schema.pkField, value)
+		const nextGroup = this._where.clone().eq(this._context.schema.pkField, value)
 		return this._clone<Sel, P>({
 			where: nextGroup,
 			select: this._select as readonly Sel[] | undefined,

--- a/src/orm/repo/repo.ts
+++ b/src/orm/repo/repo.ts
@@ -48,13 +48,13 @@ class RepoBuilder<A extends OrmAdapterLike<any>> {
 	#adapter: unknown
 	#resolve: unknown
 
-	constructor(adapter?: unknown) {
+	constructor(adapter?: unknown, resolve?: unknown) {
 		this.#adapter = adapter
+		this.#resolve = resolve
 	}
 
 	resolve(fn: (schema: AnySchema) => OrmAdapterConfig<A>): RepoBuilder<A> {
-		this.#resolve = fn
-		return this as unknown as RepoBuilder<A>
+		return new RepoBuilder<A>(this.#adapter, fn)
 	}
 
 	build(this: RepoBuilder<A>): RepoSurface<A> {
@@ -103,6 +103,15 @@ if (import.meta.vitest) {
 				.build()
 			const ref = repo.on(TestSchema)
 			expect(ref).toBeInstanceOf(SchemaRef)
+		})
+	})
+
+	describe('clone-on-step: RepoBuilder fan-out independence', () => {
+		test('.resolve() returns a new builder, not the same instance', () => {
+			const { adapter } = createInMemoryAdapter()
+			const base = Repo.from(adapter)
+			const a = base.resolve((s) => ({ table: s.name }))
+			expect(a).not.toBe(base)
 		})
 	})
 

--- a/src/orm/schema.ts
+++ b/src/orm/schema.ts
@@ -43,12 +43,15 @@ export class SchemaBuilder<
 	C extends Record<string, AnyComputedField> = {},
 > {
 	#name: N
-	#pkField: PKField | null = null
-	#fieldDefs: F = {} as F
-	#computedDefs: C = {} as C
+	#pkField: PKField | null
+	#fieldDefs: F
+	#computedDefs: C
 
-	constructor(name: N) {
+	constructor(name: N, pkField?: PKField | null, fieldDefs?: F, computedDefs?: C) {
 		this.#name = name
+		this.#pkField = pkField ?? null
+		this.#fieldDefs = fieldDefs ?? ({} as F)
+		this.#computedDefs = computedDefs ?? ({} as C)
 	}
 
 	get name() {
@@ -60,9 +63,12 @@ export class SchemaBuilder<
 		pipe: P,
 		generate: () => PipeOutput<P>,
 	): SchemaBuilder<N, SchemaField<K, P, true>, F> {
-		const builder = this as unknown as SchemaBuilder<N, SchemaField<K, P, true>, F>
-		builder.#pkField = new SchemaField(name, pipe, { onCreate: generate })
-		return builder
+		return new SchemaBuilder<N, SchemaField<K, P, true>, F>(
+			this.#name,
+			new SchemaField(name, pipe, { onCreate: generate }),
+			{ ...this.#fieldDefs } as F,
+			undefined,
+		)
 	}
 
 	field<
@@ -84,8 +90,8 @@ export class SchemaBuilder<
 					: never
 		}
 	> {
-		this.#fieldDefs[name] = new SchemaField(name, pipe, opts) as any
-		return this as any
+		const nextFields = { ...this.#fieldDefs, [name]: new SchemaField(name, pipe, opts) }
+		return new SchemaBuilder(this.#name, this.#pkField, nextFields, { ...this.#computedDefs }) as any
 	}
 
 	computed<
@@ -105,8 +111,8 @@ export class SchemaBuilder<
 			[Key in keyof C | K]: Key extends K ? ComputedField<K, P, Deps> : Key extends keyof C ? C[Key] : never
 		}
 	> {
-		this.#computedDefs[name as K] = new ComputedField(name as K, pipe, deps, compute as any) as any
-		return this as any
+		const nextComputed = { ...this.#computedDefs, [name]: new ComputedField(name as K, pipe, deps, compute as any) }
+		return new SchemaBuilder(this.#name, this.#pkField, { ...this.#fieldDefs }, nextComputed) as any
 	}
 
 	build(this: [PKField] extends [never] ? never : SchemaBuilder<N, PKField, F, C>): Schema<N, PKField, F, C> {
@@ -132,10 +138,10 @@ export class Schema<
 		this.#fieldDefs = fieldDefs
 		this.#computedDefs = computedDefs
 		if (this.#pkField) {
-			Object.defineProperty(this.#pkField, '__schema', { value: this, enumerable: false })
+			Object.defineProperty(this.#pkField, '__schema', { value: this, enumerable: false, configurable: true })
 		}
 		for (const field of Object.values(this.#fieldDefs)) {
-			Object.defineProperty(field, '__schema', { value: this, enumerable: false })
+			Object.defineProperty(field, '__schema', { value: this, enumerable: false, configurable: true })
 		}
 	}
 
@@ -357,6 +363,46 @@ if (import.meta.vitest) {
 		test('duplicate .field() name is a TS error', () => {
 			// @ts-expect-error — duplicate field name 'email' should fail
 			Schema.from('test').pk('id', v.string(), () => 'x').field('email', v.string()).field('email', v.string()).build()
+		})
+	})
+
+	describe('clone-on-step: fan-out independence', () => {
+		test('.field() returns a new builder, not the same instance', () => {
+			const base = Schema.from('test').pk('id', v.string(), () => 'x')
+			const a = base.field('email', v.string())
+			expect(a).not.toBe(base)
+		})
+
+		test('.pk() returns a new builder, not the same instance', () => {
+			const base = Schema.from('test')
+			const a = base.pk('id', v.string(), () => 'x')
+			expect(a).not.toBe(base)
+		})
+
+		test('.computed() returns a new builder, not the same instance', () => {
+			const base = Schema.from('test').pk('id', v.string(), () => 'x').field('name', v.string())
+			const a = base.computed('upper', ['name'], v.string(), ({ name }) => name.toUpperCase())
+			expect(a).not.toBe(base)
+		})
+
+		test('fan-out from shared base does not pollute either branch', () => {
+			const base = Schema.from('test').pk('id', v.string(), () => 'x')
+			const branchA = base.field('email', v.string()).build()
+			const branchB = base.field('age', v.number()).build()
+
+			expect(Object.keys(branchA.fieldDefs)).toEqual(['email'])
+			expect(Object.keys(branchB.fieldDefs)).toEqual(['age'])
+		})
+
+		test('fan-out with computed does not pollute base', () => {
+			const base = Schema.from('test')
+				.pk('id', v.string(), () => 'x')
+				.field('name', v.string())
+			const withComputed = base.computed('upper', ['name'], v.string(), ({ name }) => name.toUpperCase()).build()
+			const withoutComputed = base.build()
+
+			expect(Object.keys(withComputed.computedDefs)).toEqual(['upper'])
+			expect(Object.keys(withoutComputed.computedDefs)).toEqual([])
 		})
 	})
 


### PR DESCRIPTION
RALPH: PRD #27, issue #53

Convert all artifact builders and filter sub-builders from in-place mutation (`return this`) to clone-on-step (each step constructs a new builder instance with updated state).

Key decisions:
- SchemaBuilder: constructor accepts optional state args; .pk(), .field(), .computed() each spread existing state into a new instance. Made __schema property configurable to support fan-out where the same SchemaField instance is built into multiple Schemas.
- RelationsBuilder: constructor accepts optional defs record; each relation method spreads defs and returns new builder.
- RepoBuilder: constructor accepts optional resolve fn; .resolve() returns new builder.
- FilterGroup: children changed from mutable array to readonly. Each filter op and and()/or() returns new FilterGroup via #withChild(). Updated ReadSelectState.where() and OneBuilder.id() to use return values instead of relying on mutation.
- QueryGroup: same pattern as FilterGroup — readonly children, each op returns new QueryGroup.
- Per-call query builders (OneBuilder, AllBuilder) were already clone-based — no change needed.

Fan-out independence tests added for all five builder types, asserting that forking a shared base into two chains does not mutate the base or cross-pollinate branches.

Files changed:
- src/orm/schema.ts (SchemaBuilder clone-on-step + 5 fan-out tests)
- src/orm/relations.ts (RelationsBuilder clone-on-step + 4 fan-out tests)
- src/orm/repo/repo.ts (RepoBuilder clone-on-step + 1 fan-out test)
- src/orm/filter.ts (FilterGroup clone-on-step + 4 fan-out tests)
- src/orm/query.ts (QueryGroup clone-on-step + 4 fan-out tests)
- src/orm/repo/builders.ts (where/id updated to use return values)