### PR TITLE
Sandcastle: Migrate jobs adapter (`RedisJob`) to class-via-`configurable` + class-keyed Instance hooks (#47)

### DIFF
--- a/src/instance/hooks.ts
+++ b/src/instance/hooks.ts
@@ -1,7 +1,7 @@
 export type HookEvent = 'setup' | 'start' | 'close'
 export type HookCb = Promise<unknown | void> | (() => void | unknown | Promise<void | unknown>)
 
-export type ClassRef = abstract new (...args: any[]) => any
+export type ClassRef = Function & { prototype: unknown }
 export type HookOptions = {
 	class?: ClassRef
 	after?: ClassRef[]

--- a/src/jobs/adapters/redis/index.ts
+++ b/src/jobs/adapters/redis/index.ts
@@ -1,5 +1,5 @@
 import { Queue, Worker } from 'bullmq'
-import { v, type PipeOutput } from 'valleyed'
+import { v } from 'valleyed'
 
 import { RedisCache, redisConfigPipe } from '../../../cache/adapters/redis'
 import { Instance } from '../../../instance'
@@ -15,94 +15,106 @@ export const redisJobsConfigPipe = () =>
 		{ title: 'Redis Jobs Config', $refId: 'RedisJobsConfig' },
 	)
 
-export class RedisJob extends configurable(
-	redisJobsConfigPipe,
-	class extends Job {
-		#queue: Queue
-		constructor(config: PipeOutput<ReturnType<typeof redisJobsConfigPipe>>) {
-			super()
+export class RedisJob extends configurable(redisJobsConfigPipe, Job) {
+	#queue: Queue
 
-			const redisCache = (RedisCache.create as any)(config.redisConfig, {
-				maxRetriesPerRequest: null,
-				enableReadyCheck: false,
-			})
-			const queueName = Instance.get().getScopedName(config.queueName)
-			this.#queue = new Queue(queueName, { connection: redisCache.connectionOptions, skipVersionCheck: true })
+	protected constructor(config: typeof RedisJob.Config) {
+		super(config)
 
-			const worker = new Worker(
-				queueName,
-				async (job) => {
-					switch (job.name) {
-						case JobNames.DelayedJob:
-							return (this.callbacks.onDelayed as any)?.(job.data)
-						case JobNames.CronJob:
-							return (this.callbacks.onCron as any)?.(job.data.type)
-						case JobNames.RepeatableJob:
-							return (this.callbacks.onRepeatable as any)?.(job.data)
-					}
-				},
-				{ connection: redisCache.connectionOptions, autorun: false, skipVersionCheck: true },
-			)
+		const redisCache = (RedisCache.create as any)(config.redisConfig, {
+			maxRetriesPerRequest: null,
+			enableReadyCheck: false,
+		})
+		const queueName = Instance.get().getScopedName(config.queueName)
+		this.#queue = new Queue(queueName, { connection: redisCache.connectionOptions, skipVersionCheck: true })
 
-			Instance.on('start', async () => {
-				await this.#cleanup()
-				await Promise.all(this.crons.map(({ cron, name }) => this.#addCron(name, cron)))
-				worker.run()
-			})
-		}
+		const worker = new Worker(
+			queueName,
+			async (job) => {
+				switch (job.name) {
+					case JobNames.DelayedJob:
+						return (this.callbacks.onDelayed as any)?.(job.data)
+					case JobNames.CronJob:
+						return (this.callbacks.onCron as any)?.(job.data.type)
+					case JobNames.RepeatableJob:
+						return (this.callbacks.onRepeatable as any)?.(job.data)
+				}
+			},
+			{ connection: redisCache.connectionOptions, autorun: false, skipVersionCheck: true },
+		)
 
-		#getNewId() {
-			return [Date.now(), Random.string()].join('_')
-		}
+		Instance.on('start', async () => {
+			await this.#cleanup()
+			await Promise.all(this.crons.map(({ cron, name }) => this.#addCron(name, cron)))
+			worker.run()
+		}, { class: RedisJob })
+	}
 
-		async #addCron(type: Cron | string, cron: string) {
-			const job = await this.#queue.add(
-				JobNames.CronJob,
-				{ type },
-				{
-					jobId: this.#getNewId(),
-					repeat: { pattern: cron },
-					removeOnComplete: true,
-					backoff: 1000,
-					attempts: 3,
-				},
-			)
-			return job.id!.toString()
-		}
+	#getNewId() {
+		return [Date.now(), Random.string()].join('_')
+	}
 
-		async #cleanup() {
-			await this.retryAllFailedJobs()
-			const repeatableJobs = await this.#queue.getJobSchedulers()
-			await Promise.all(repeatableJobs.map((job) => this.#queue.removeJobScheduler(job.key)))
-		}
-
-		async addDelayed(data: DelayedJobEvent, delayInMs: number): Promise<string> {
-			const job = await this.#queue.add(JobNames.DelayedJob, data, {
+	async #addCron(type: Cron | string, cron: string) {
+		const job = await this.#queue.add(
+			JobNames.CronJob,
+			{ type },
+			{
 				jobId: this.#getNewId(),
-				delay: delayInMs,
+				repeat: { pattern: cron },
 				removeOnComplete: true,
 				backoff: 1000,
 				attempts: 3,
-			})
-			return job.id!.toString()
-		}
-		async addRepeatable(data: RepeatableJobEvent, cron: string, tz?: string): Promise<string> {
-			const job = await this.#queue.add(JobNames.RepeatableJob, data, {
-				jobId: this.#getNewId(),
-				repeat: { pattern: cron, ...(tz ? { tz } : {}) },
-				removeOnComplete: true,
-				backoff: 1000,
-				attempts: 3,
-			})
-			return job.opts?.repeat?.key ?? ''
-		}
-		async removeDelayed(jobId: string) {
-			const job = await this.#queue.getJob(jobId)
-			if (job) await job.remove()
-		}
-		async retryAllFailedJobs() {
-			const failedJobs = await this.#queue.getFailed()
-			await Promise.all(failedJobs.map((job) => job.retry()))
-		}
-	},
-) {}
+			},
+		)
+		return job.id!.toString()
+	}
+
+	async #cleanup() {
+		await this.retryAllFailedJobs()
+		const repeatableJobs = await this.#queue.getJobSchedulers()
+		await Promise.all(repeatableJobs.map((job) => this.#queue.removeJobScheduler(job.key)))
+	}
+
+	async addDelayed(data: DelayedJobEvent, delayInMs: number): Promise<string> {
+		const job = await this.#queue.add(JobNames.DelayedJob, data, {
+			jobId: this.#getNewId(),
+			delay: delayInMs,
+			removeOnComplete: true,
+			backoff: 1000,
+			attempts: 3,
+		})
+		return job.id!.toString()
+	}
+	async addRepeatable(data: RepeatableJobEvent, cron: string, tz?: string): Promise<string> {
+		const job = await this.#queue.add(JobNames.RepeatableJob, data, {
+			jobId: this.#getNewId(),
+			repeat: { pattern: cron, ...(tz ? { tz } : {}) },
+			removeOnComplete: true,
+			backoff: 1000,
+			attempts: 3,
+		})
+		return job.opts?.repeat?.key ?? ''
+	}
+	async removeDelayed(jobId: string) {
+		const job = await this.#queue.getJob(jobId)
+		if (job) await job.remove()
+	}
+	async retryAllFailedJobs() {
+		const failedJobs = await this.#queue.getFailed()
+		await Promise.all(failedJobs.map((job) => job.retry()))
+	}
+}
+
+if (import.meta.vitest) {
+	const { test, expectTypeOf } = import.meta.vitest
+	type PipeOutput<P> = import('valleyed').PipeOutput<P>
+
+	test('external new is a compile error', () => {
+		// @ts-expect-error — protected constructor prevents external instantiation
+		void (() => new RedisJob({ redisConfig: { host: '' }, queueName: '' }))
+	})
+
+	test('Config type matches pipe output', () => {
+		expectTypeOf<typeof RedisJob.Config>().toEqualTypeOf<PipeOutput<ReturnType<typeof redisJobsConfigPipe>>>()
+	})
+}

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -166,14 +166,7 @@ export class OneBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 	}
 
 	protected _clone<NewSel extends string, NewP extends readonly AnyPreloadDef[]>(next: ReadState<NewSel, NewP>) {
-		return new OneBuilder<S, A, NewSel, NewP>(
-			this._context,
-			this._readState({
-				where: next.where,
-				select: next.select,
-				preloads: next.preloads,
-			}),
-		) as any
+		return new OneBuilder<S, A, NewSel, NewP>(this._context, this._readState(next)) as any
 	}
 
 	create(data: SchemaCreateInput<S>) {
@@ -251,51 +244,31 @@ export class AllBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 	}
 
 	protected _clone<NewSel extends string, NewP extends readonly AnyPreloadDef[]>(next: ReadState<NewSel, NewP>) {
-		return new AllBuilder<S, A, NewSel, NewP>(
-			this._context,
-			this._readState({
-				where: next.where,
-				select: next.select,
-				preloads: next.preloads,
-			}),
-			this.#queryState(),
-		) as any
+		return new AllBuilder<S, A, NewSel, NewP>(this._context, this._readState(next), this.#queryState()) as any
 	}
 
 	orderBy(field: string | AnyField, direction: 'asc' | 'desc' = 'asc') {
-		return new AllBuilder<S, A, Sel, P>(
-			this._context,
-			this._readState({
-				where: this._where.clone(),
-				select: this._select as readonly Sel[] | undefined,
-				preloads: this._preloads,
-			}),
-			{ orderBy: [...this.#orderBy, new OrderBy(field, direction)], limit: this.#limit, offset: this.#offset },
-		) as this
+		return new AllBuilder<S, A, Sel, P>(this._context, this._readState(), {
+			orderBy: [...this.#orderBy, new OrderBy(field, direction)],
+			limit: this.#limit,
+			offset: this.#offset,
+		}) as this
 	}
 
 	limit(limit: number) {
-		return new AllBuilder<S, A, Sel, P>(
-			this._context,
-			this._readState({
-				where: this._where.clone(),
-				select: this._select as readonly Sel[] | undefined,
-				preloads: this._preloads,
-			}),
-			{ orderBy: [...this.#orderBy], limit, offset: this.#offset },
-		) as this
+		return new AllBuilder<S, A, Sel, P>(this._context, this._readState(), {
+			orderBy: [...this.#orderBy],
+			limit,
+			offset: this.#offset,
+		}) as this
 	}
 
 	offset(offset: number) {
-		return new AllBuilder<S, A, Sel, P>(
-			this._context,
-			this._readState({
-				where: this._where.clone(),
-				select: this._select as readonly Sel[] | undefined,
-				preloads: this._preloads,
-			}),
-			{ orderBy: [...this.#orderBy], limit: this.#limit, offset },
-		) as this
+		return new AllBuilder<S, A, Sel, P>(this._context, this._readState(), {
+			orderBy: [...this.#orderBy],
+			limit: this.#limit,
+			offset,
+		}) as this
 	}
 
 	create(data: SchemaCreateInput<S>[]) {

--- a/src/utilities/configurable.ts
+++ b/src/utilities/configurable.ts
@@ -2,10 +2,10 @@ import { v, type Pipe, type PipeInput, type PipeOutput } from 'valleyed'
 
 type CtorParams<T> = ConstructorParameters<T & (abstract new (...args: any[]) => any)>
 
-export function configurable<P extends Pipe<any, any>, Base extends new (...args: any[]) => any>(pipeFn: () => P, base: Base) {
+export function configurable<P extends Pipe<any, any>, Base extends abstract new (...args: any[]) => any>(pipeFn: () => P, base: Base) {
 	let pipe: P | undefined
 
-	abstract class Configurable extends (base as new (...args: any[]) => any) {
+	abstract class Configurable extends (base as unknown as new (...args: any[]) => any) {
 		declare static readonly Config: PipeOutput<P>
 
 		protected readonly config: PipeOutput<P>


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #47.

Closes #47

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._