### PR TITLE
Sandcastle: Aggregation slice 2: extend OrmValidationError with 'aggregate' kind + alias? carrier (#74)

### DIFF
--- a/src/orm/errors/validation.ts
+++ b/src/orm/errors/validation.ts
@@ -31,73 +31,42 @@ if (import.meta.vitest) {
 	const { EquippedError } = await import('../../errors')
 
 	describe('OrmValidationError', () => {
-		describe('aggregate kind', () => {
-			test('accepts aggregate as kind', () => {
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
-				expect(err.kind).toBe('aggregate')
-			})
-
-			test('accepts aggregate as operation', () => {
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
-				expect(err.operation).toBe('aggregate')
-			})
-
-			test('formats message with aggregate kind and operation', () => {
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
-				expect(err.message).toBe('ORM validation error (aggregate) on orders.aggregate')
-			})
+		test('constructs with aggregate kind', () => {
+			const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+			expect(err.kind).toBe('aggregate')
+			expect(err.operation).toBe('aggregate')
+			expect(err.message).toBe('ORM validation error (aggregate) on orders.aggregate')
+			expect(err).toBeInstanceOf(OrmValidationError)
+			expect(err).toBeInstanceOf(EquippedError)
 		})
 
-		describe('alias carrier on failures', () => {
-			test('failure entry accepts optional alias', () => {
-				const failures: OrmValidationFailure[] = [
-					{ alias: 'total_price', cause: 'alias collision' },
-				]
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', failures)
-				expect(err.failures[0].alias).toBe('total_price')
-			})
-
-			test('failure entry without alias still works', () => {
-				const failures: OrmValidationFailure[] = [
-					{ field: 'amount', cause: 'invalid field' },
-				]
-				const err = new OrmValidationError('validation', 'orders', 'createOne', failures)
-				expect(err.failures[0].alias).toBeUndefined()
-				expect(err.failures[0].field).toBe('amount')
-			})
-
-			test('alias is included in the error context', () => {
-				const failures: OrmValidationFailure[] = [
-					{ alias: 'avg_price', cause: 'having-alias-not-found' },
-				]
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', failures)
-				expect((err.context as any).failures[0].alias).toBe('avg_price')
-			})
+		test('failure carries alias through to context', () => {
+			const failures: OrmValidationFailure[] = [
+				{ alias: 'total_price', cause: 'alias collision' },
+			]
+			const err = new OrmValidationError('aggregate', 'orders', 'aggregate', failures)
+			expect(err.failures[0].alias).toBe('total_price')
+			expect((err.context as any).failures[0].alias).toBe('total_price')
 		})
 
-		describe('existing kinds unchanged', () => {
-			test.each([
-				'validation',
-				'conflicting-ops',
-				'empty-group',
-				'undeclared-op',
-				'upsert-filter-incompatible',
-			] as const)('kind %s still works', (kind) => {
-				const err = new OrmValidationError(kind, 'users', 'createOne', [])
-				expect(err.kind).toBe(kind)
-			})
+		test('failure without alias still works', () => {
+			const failures: OrmValidationFailure[] = [
+				{ field: 'amount', cause: 'invalid field' },
+			]
+			const err = new OrmValidationError('validation', 'orders', 'createOne', failures)
+			expect(err.failures[0].alias).toBeUndefined()
+			expect(err.failures[0].field).toBe('amount')
 		})
 
-		describe('instanceof discrimination', () => {
-			test('aggregate error is instanceof OrmValidationError', () => {
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
-				expect(err).toBeInstanceOf(OrmValidationError)
-			})
-
-			test('aggregate error is instanceof EquippedError', () => {
-				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
-				expect(err).toBeInstanceOf(EquippedError)
-			})
+		test.each([
+			'validation',
+			'conflicting-ops',
+			'empty-group',
+			'undeclared-op',
+			'upsert-filter-incompatible',
+		] as const)('kind %s still works', (kind) => {
+			const err = new OrmValidationError(kind, 'users', 'createOne', [])
+			expect(err.kind).toBe(kind)
 		})
 	})
 }

--- a/src/orm/errors/validation.ts
+++ b/src/orm/errors/validation.ts
@@ -1,11 +1,12 @@
 import { EquippedError } from '../../errors'
 
-export type OrmValidationErrorKind = 'validation' | 'conflicting-ops' | 'empty-group' | 'undeclared-op' | 'upsert-filter-incompatible'
+export type OrmValidationErrorKind = 'validation' | 'conflicting-ops' | 'empty-group' | 'undeclared-op' | 'upsert-filter-incompatible' | 'aggregate'
 
 export type OrmValidationFailure = {
 	opIndex?: number
 	rowIndex?: number
 	field?: string
+	alias?: string
 	cause: unknown
 }
 
@@ -23,4 +24,80 @@ export class OrmValidationError extends EquippedError {
 			failures,
 		})
 	}
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect } = import.meta.vitest
+	const { EquippedError } = await import('../../errors')
+
+	describe('OrmValidationError', () => {
+		describe('aggregate kind', () => {
+			test('accepts aggregate as kind', () => {
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+				expect(err.kind).toBe('aggregate')
+			})
+
+			test('accepts aggregate as operation', () => {
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+				expect(err.operation).toBe('aggregate')
+			})
+
+			test('formats message with aggregate kind and operation', () => {
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+				expect(err.message).toBe('ORM validation error (aggregate) on orders.aggregate')
+			})
+		})
+
+		describe('alias carrier on failures', () => {
+			test('failure entry accepts optional alias', () => {
+				const failures: OrmValidationFailure[] = [
+					{ alias: 'total_price', cause: 'alias collision' },
+				]
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', failures)
+				expect(err.failures[0].alias).toBe('total_price')
+			})
+
+			test('failure entry without alias still works', () => {
+				const failures: OrmValidationFailure[] = [
+					{ field: 'amount', cause: 'invalid field' },
+				]
+				const err = new OrmValidationError('validation', 'orders', 'createOne', failures)
+				expect(err.failures[0].alias).toBeUndefined()
+				expect(err.failures[0].field).toBe('amount')
+			})
+
+			test('alias is included in the error context', () => {
+				const failures: OrmValidationFailure[] = [
+					{ alias: 'avg_price', cause: 'having-alias-not-found' },
+				]
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', failures)
+				expect((err.context as any).failures[0].alias).toBe('avg_price')
+			})
+		})
+
+		describe('existing kinds unchanged', () => {
+			test.each([
+				'validation',
+				'conflicting-ops',
+				'empty-group',
+				'undeclared-op',
+				'upsert-filter-incompatible',
+			] as const)('kind %s still works', (kind) => {
+				const err = new OrmValidationError(kind, 'users', 'createOne', [])
+				expect(err.kind).toBe(kind)
+			})
+		})
+
+		describe('instanceof discrimination', () => {
+			test('aggregate error is instanceof OrmValidationError', () => {
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+				expect(err).toBeInstanceOf(OrmValidationError)
+			})
+
+			test('aggregate error is instanceof EquippedError', () => {
+				const err = new OrmValidationError('aggregate', 'orders', 'aggregate', [])
+				expect(err).toBeInstanceOf(EquippedError)
+			})
+		})
+	})
 }


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #74.

Closes #74

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._