### PR TITLE
Sandcastle: Aggregation slice 3: tracer — count-only end-to-end via in-memory (#76)

### DIFF
--- a/src/orm/adapters/base.ts
+++ b/src/orm/adapters/base.ts
@@ -1,4 +1,5 @@
 import type { FilterGroup } from '../filter'
+import type { AggregateSpec } from '../orm-adapter'
 import type { QueryOptions } from '../query'
 import type { AnySchema } from '../schema'
 import type { AnyUpdateOp } from '../updates'
@@ -14,6 +15,8 @@ export type OrmUse = {
 	deleteOne: (filter: FilterGroup) => Promise<Record<string, unknown> | null>
 	deleteMany: (filter: FilterGroup) => Promise<Record<string, unknown>[]>
 	raw: (...args: any[]) => Promise<any>
+	aggregate: (spec: AggregateSpec) => Promise<Array<Record<string, unknown>>>
+	aggregateOps: readonly string[]
 }
 
 export type OrmAdapterLike<Config = unknown> = {

--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -4,7 +4,7 @@ import { v, differ } from 'valleyed'
 
 import { configurable } from '../../../utilities/configurable'
 import { Filter, FilterGroup, type FilterChild } from '../../filter'
-import { OrmAdapter } from '../../orm-adapter'
+import { OrmAdapter, type AggregateSpec } from '../../orm-adapter'
 import type { QueryOptions } from '../../query'
 import type { AnySchema } from '../../schema'
 import { IncOp, MaxOp, MinOp, MulOp, PatchOp, PullOp, PushOp, SetOp, UnsetOp, type AnyUpdateOp } from '../../updates'
@@ -224,6 +224,7 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 	readonly supportedFieldTypes = ['string', 'number', 'boolean', 'null', 'object', 'array', 'date'] as const
 	readonly queryableOps = ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'like', 'exists', 'notExists', 'contains', 'notContains'] as const
 	readonly updateOps = ['set', 'inc', 'mul', 'min', 'max', 'unset', 'push', 'pull', 'patch'] as const
+	readonly aggregateOps = ['count'] as const
 
 	readonly stores = new Map<string, Map<string, Record<string, unknown>>>()
 
@@ -337,6 +338,21 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 		const result = ops.length > 0 ? applyOps(base, ops) : base
 		store.set(String(result[pk]), result)
 		return clone(result)
+	}
+
+	async aggregate(schema: AnySchema, config: unknown, spec: AggregateSpec): Promise<Array<Record<string, unknown>>> {
+		const store = this.#resolveStore(schema, config)
+		let rows = [...store.values()]
+		if (spec.where) {
+			rows = rows.filter((doc) => matchesFilter(doc, spec.where!))
+		}
+		const result: Record<string, unknown> = {}
+		for (const agg of spec.aggregates) {
+			if (agg.fn === 'count') {
+				result[agg.alias] = rows.length
+			}
+		}
+		return [result]
 	}
 
 	async session<T>(fn: () => Promise<T>): Promise<T> {
@@ -482,6 +498,62 @@ if (import.meta.vitest) {
 			expect(onSpy).not.toHaveBeenCalled()
 
 			onSpy.mockRestore()
+		})
+
+		test('declares aggregateOps with count', () => {
+			const adapter = InMemoryAdapter.create({})
+			expect(adapter.aggregateOps).toEqual(['count'])
+		})
+
+		test('aggregate count returns correct total', async () => {
+			const schema = Schema.from('items')
+				.pk('id', v.string(), () => `i-${Math.random().toString(36).slice(2, 8)}`)
+				.field('category', v.string())
+				.build()
+			const adapter = InMemoryAdapter.create({})
+			const use = adapter.use(schema, { table: 'items' })
+			await use.createMany([
+				{ id: 'i1', category: 'A' },
+				{ id: 'i2', category: 'B' },
+				{ id: 'i3', category: 'A' },
+			])
+			const result = await adapter.aggregate(schema, { table: 'items' }, {
+				aggregates: [{ fn: 'count', alias: 'total' }],
+				groupBy: [],
+			})
+			expect(result).toEqual([{ total: 3 }])
+		})
+
+		test('aggregate count with where filter', async () => {
+			const schema = Schema.from('items')
+				.pk('id', v.string(), () => `i-${Math.random().toString(36).slice(2, 8)}`)
+				.field('category', v.string())
+				.build()
+			const adapter = InMemoryAdapter.create({})
+			const use = adapter.use(schema, { table: 'items' })
+			await use.createMany([
+				{ id: 'i1', category: 'A' },
+				{ id: 'i2', category: 'B' },
+				{ id: 'i3', category: 'A' },
+			])
+			const result = await adapter.aggregate(schema, { table: 'items' }, {
+				aggregates: [{ fn: 'count', alias: 'total' }],
+				groupBy: [],
+				where: FilterGroup.create().eq('category', 'A'),
+			})
+			expect(result).toEqual([{ total: 2 }])
+		})
+
+		test('aggregate count on empty store returns zero', async () => {
+			const schema = Schema.from('items')
+				.pk('id', v.string(), () => 'x')
+				.build()
+			const adapter = InMemoryAdapter.create({})
+			const result = await adapter.aggregate(schema, { table: 'items' }, {
+				aggregates: [{ fn: 'count', alias: 'total' }],
+				groupBy: [],
+			})
+			expect(result).toEqual([{ total: 0 }])
 		})
 	})
 }

--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -344,7 +344,8 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 		const store = this.#resolveStore(schema, config)
 		let rows = [...store.values()]
 		if (spec.where) {
-			rows = rows.filter((doc) => matchesFilter(doc, spec.where!))
+			const where = spec.where
+			rows = rows.filter((doc) => matchesFilter(doc, where))
 		}
 		const result: Record<string, unknown> = {}
 		for (const agg of spec.aggregates) {

--- a/src/orm/filter.ts
+++ b/src/orm/filter.ts
@@ -1,6 +1,7 @@
 import type { FilterOpName } from './adapter'
 import { EquippedError } from '../errors'
-import { OrmValidationError } from './errors'
+import { OrmValidationError, type OrmValidationFailure } from './errors'
+import type { AggregateSpec } from './orm-adapter'
 import { toFieldName, type AnyField, type Field } from './fields'
 import type { AnySchema } from './schema'
 
@@ -123,8 +124,8 @@ export type GatedFilterFactory<DeclaredOps extends readonly FilterOpName[]> = (
 	q: GatedFilterGroup<DeclaredOps>,
 ) => GatedFilterGroup<DeclaredOps>
 
-export function assertNormalisedAggregate(schema: AnySchema, adapter: { aggregateOps: readonly string[] }, spec: import('./orm-adapter').AggregateSpec): void {
-	const failures: import('./errors').OrmValidationFailure[] = []
+export function assertNormalisedAggregate(schema: AnySchema, adapter: { aggregateOps: readonly string[] }, spec: AggregateSpec): void {
+	const failures: OrmValidationFailure[] = []
 
 	if (spec.aggregates.length === 0) {
 		failures.push({ cause: 'At least one aggregator step is required' })

--- a/src/orm/filter.ts
+++ b/src/orm/filter.ts
@@ -123,6 +123,34 @@ export type GatedFilterFactory<DeclaredOps extends readonly FilterOpName[]> = (
 	q: GatedFilterGroup<DeclaredOps>,
 ) => GatedFilterGroup<DeclaredOps>
 
+export function assertNormalisedAggregate(schema: AnySchema, adapter: { aggregateOps: readonly string[] }, spec: import('./orm-adapter').AggregateSpec): void {
+	const failures: import('./errors').OrmValidationFailure[] = []
+
+	if (spec.aggregates.length === 0) {
+		failures.push({ cause: 'At least one aggregator step is required' })
+	}
+
+	const seenAliases = new Set<string>()
+	for (const agg of spec.aggregates) {
+		if (seenAliases.has(agg.alias)) {
+			failures.push({ alias: agg.alias, cause: `Duplicate alias "${agg.alias}"` })
+		}
+		seenAliases.add(agg.alias)
+
+		if (!adapter.aggregateOps.includes(agg.fn)) {
+			failures.push({ alias: agg.alias, cause: `Undeclared aggregate op "${agg.fn}"` })
+		}
+	}
+
+	if (failures.length > 0) {
+		throw new OrmValidationError('aggregate', schema.name, 'aggregate', failures)
+	}
+
+	if (spec.where) {
+		assertNormalisedFilter(schema, spec.where)
+	}
+}
+
 export function assertNormalisedFilter(schema: AnySchema, group: FilterGroup): void {
 	const allFields = schema.fields as Record<string, unknown>
 	const fieldNames = new Set(Object.keys(allFields))
@@ -422,6 +450,84 @@ if (import.meta.vitest) {
 				(q) => q.or([(inner) => inner.eq('nonexistent', 'val')]),
 			])
 			expect(() => assertNormalisedFilter(UserSchema, g)).toThrow(OrmValidationError)
+		})
+	})
+
+	describe('assertNormalisedAggregate', () => {
+		const adapter = { aggregateOps: ['count'] as readonly string[] }
+
+		test('passes for valid count aggregate', () => {
+			const spec = { aggregates: [{ fn: 'count' as const, alias: 'total' }], groupBy: [] }
+			expect(() => assertNormalisedAggregate(UserSchema, adapter, spec)).not.toThrow()
+		})
+
+		test('rejects empty aggregator list', () => {
+			const spec = { aggregates: [], groupBy: [] }
+			expect(() => assertNormalisedAggregate(UserSchema, adapter, spec)).toThrow(OrmValidationError)
+			try {
+				assertNormalisedAggregate(UserSchema, adapter, spec)
+				expect.unreachable()
+			} catch (e) {
+				expect((e as OrmValidationError).kind).toBe('aggregate')
+			}
+		})
+
+		test('rejects undeclared aggregate op', () => {
+			const spec = { aggregates: [{ fn: 'sum' as const, alias: 'total', field: 'age' }], groupBy: [] }
+			expect(() => assertNormalisedAggregate(UserSchema, adapter, spec)).toThrow(OrmValidationError)
+			try {
+				assertNormalisedAggregate(UserSchema, adapter, spec)
+				expect.unreachable()
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.kind).toBe('aggregate')
+				expect(err.failures[0].alias).toBe('total')
+				expect(err.failures[0].cause).toContain('Undeclared')
+			}
+		})
+
+		test('rejects duplicate aliases', () => {
+			const spec = {
+				aggregates: [
+					{ fn: 'count' as const, alias: 'total' },
+					{ fn: 'count' as const, alias: 'total' },
+				],
+				groupBy: [],
+			}
+			expect(() => assertNormalisedAggregate(UserSchema, adapter, spec)).toThrow(OrmValidationError)
+			try {
+				assertNormalisedAggregate(UserSchema, adapter, spec)
+				expect.unreachable()
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.failures.some((f) => f.alias === 'total')).toBe(true)
+			}
+		})
+
+		test('validates where filter against schema', () => {
+			const spec = {
+				aggregates: [{ fn: 'count' as const, alias: 'total' }],
+				groupBy: [],
+				where: FilterGroup.create().eq('unknownField', 42),
+			}
+			expect(() => assertNormalisedAggregate(UserSchema, adapter, spec)).toThrow(OrmValidationError)
+		})
+
+		test('collects multiple failures', () => {
+			const spec = {
+				aggregates: [
+					{ fn: 'sum' as const, alias: 'x', field: 'age' },
+					{ fn: 'avg' as const, alias: 'x', field: 'age' },
+				],
+				groupBy: [],
+			}
+			try {
+				assertNormalisedAggregate(UserSchema, adapter, spec)
+				expect.unreachable()
+			} catch (e) {
+				const err = e as OrmValidationError
+				expect(err.failures.length).toBeGreaterThanOrEqual(2)
+			}
 		})
 	})
 }

--- a/src/orm/orm-adapter.ts
+++ b/src/orm/orm-adapter.ts
@@ -101,6 +101,8 @@ export abstract class OrmAdapter {
 			},
 			deleteMany: (filter) => self.deleteMany?.(schema, config, filter) ?? Promise.resolve([]),
 			raw: (...args: any[]) => self.raw?.(schema, config, ...args) ?? Promise.reject(new Error('raw not implemented')),
+			aggregate: (spec) => self.aggregate?.(schema, config, spec) ?? Promise.reject(new Error('aggregate not implemented')),
+			aggregateOps: self.aggregateOps ?? [],
 		}
 		return use
 	}

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -1,14 +1,16 @@
-import type { InferRawArgs, InferRawReturn } from '../adapter'
+import type { AggregateOpName, InferRawArgs, InferRawReturn } from '../adapter'
 import type { OrmUse } from '../adapters/base'
 import { OrmNotFoundError, type OrmNotFoundOperation } from '../errors'
 import type { AnyField } from '../fields'
 import { FilterGroup, type FilterFactory } from '../filter'
+import type { AggregateSpec } from '../orm-adapter'
 import { OrderBy } from '../query'
 import type { AnyPreloadDef } from '../relations'
 import type { AnySchema, SchemaOutput } from '../schema'
 import type { SchemaCreateInput, SchemaUpdateInput } from '../schema-validations'
 import { applyComputedSelection, planSelection } from './internals/computeds'
 import {
+	runAggregate,
 	runAllCreate,
 	runAllDelete,
 	runAllRead,
@@ -161,8 +163,8 @@ export class SchemaRef<S extends AnySchema, A = unknown> {
 		return new AllBuilder<S, A, never, []>(this.#context) as AllBuilderSurface<S, A, never, []>
 	}
 
-	aggregate() {
-		throw new Error('AggregateBuilder not yet implemented')
+	aggregate(): AggregateBuilder<S, A, {}, false> {
+		return new AggregateBuilder<S, A, {}, false>(this.#context)
 	}
 
 	raw(...args: any[]) {
@@ -358,6 +360,54 @@ export class AllBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 			limit: this.#limit,
 			offset: this.#offset,
 		})
+	}
+}
+
+type AggregateEntry = { fn: AggregateOpName; alias: string; field?: string }
+
+export class AggregateBuilder<S extends AnySchema, A = unknown, Aggs = {}, HasGroupBy extends boolean = false> {
+	readonly #context: SchemaContext<S>
+	readonly #where: FilterGroup
+	readonly #aggregates: readonly AggregateEntry[]
+
+	constructor(
+		context: SchemaContext<S>,
+		state?: { where?: FilterGroup; aggregates?: readonly AggregateEntry[] },
+	) {
+		this.#context = context
+		this.#where = state?.where ? state.where.clone() : FilterGroup.create()
+		this.#aggregates = state?.aggregates ?? []
+	}
+
+	where(factory: FilterFactory): AggregateBuilder<S, A, Aggs, HasGroupBy> {
+		const nextGroup = factory(this.#where.clone())
+		return new AggregateBuilder<S, A, Aggs, HasGroupBy>(this.#context, {
+			where: nextGroup,
+			aggregates: this.#aggregates,
+		})
+	}
+
+	count<K extends string>(
+		...[alias]: K extends keyof Aggs ? [never] : [alias: K]
+	): AggregateBuilder<S, A, Aggs & Record<K, number>, HasGroupBy> {
+		return new AggregateBuilder<S, A, Aggs & Record<K, number>, HasGroupBy>(this.#context, {
+			where: this.#where,
+			aggregates: [...this.#aggregates, { fn: 'count', alias: alias as string }],
+		})
+	}
+
+	async run(
+		..._: [keyof Aggs] extends [never] ? [never] : []
+	): Promise<HasGroupBy extends true ? Aggs[] : Aggs> {
+		const spec: AggregateSpec = {
+			aggregates: this.#aggregates,
+			groupBy: [],
+		}
+		if (this.#where.children.length > 0) {
+			spec.where = this.#where
+		}
+		const rows = await runAggregate(this.#context, spec)
+		return rows[0] as any
 	}
 }
 

--- a/src/orm/repo/builders.ts
+++ b/src/orm/repo/builders.ts
@@ -1,4 +1,4 @@
-import type { AggregateOpName, InferRawArgs, InferRawReturn } from '../adapter'
+import type { InferRawArgs, InferRawReturn } from '../adapter'
 import type { OrmUse } from '../adapters/base'
 import { OrmNotFoundError, type OrmNotFoundOperation } from '../errors'
 import type { AnyField } from '../fields'
@@ -363,7 +363,7 @@ export class AllBuilder<S extends AnySchema, A = unknown, Sel extends string = n
 	}
 }
 
-type AggregateEntry = { fn: AggregateOpName; alias: string; field?: string }
+type AggregateEntry = AggregateSpec['aggregates'][number]
 
 export class AggregateBuilder<S extends AnySchema, A = unknown, Aggs = {}, HasGroupBy extends boolean = false> {
 	readonly #context: SchemaContext<S>

--- a/src/orm/repo/internals/executors.ts
+++ b/src/orm/repo/internals/executors.ts
@@ -1,6 +1,7 @@
 import { planSelection } from './computeds'
 import type { SelectedWithPreloads } from './types'
-import { assertNormalisedFilter, type FilterGroup } from '../../filter'
+import { assertNormalisedAggregate, assertNormalisedFilter, type FilterGroup } from '../../filter'
+import type { AggregateSpec } from '../../orm-adapter'
 import type { OrderBy } from '../../query'
 import type { AnyPreloadDef } from '../../relations'
 import type { AnySchema } from '../../schema'
@@ -132,4 +133,12 @@ export async function runAllDelete<S extends AnySchema, Sel extends string, P ex
 	assertNormalisedFilter(context.schema, state.where)
 	const rows = await context.use.deleteMany(state.where)
 	return context.shapeRows(state.select, state.preloads, rows)
+}
+
+export async function runAggregate<S extends AnySchema>(
+	context: SchemaContext<S>,
+	spec: AggregateSpec,
+): Promise<Array<Record<string, unknown>>> {
+	assertNormalisedAggregate(context.schema, context.use, spec)
+	return context.use.aggregate(spec)
 }

--- a/src/orm/repo/repo.ts
+++ b/src/orm/repo/repo.ts
@@ -82,6 +82,7 @@ if (import.meta.vitest) {
 	const { v } = await import('valleyed')
 	const { InMemoryAdapter } = await import('../adapters/in-memory')
 	const { OrmAdapter } = await import('../orm-adapter')
+	const { OrmValidationError } = await import('../errors')
 	const { Instance } = await import('../../instance')
 	const { Relations } = await import('../relations')
 	const { Schema } = await import('../schema')
@@ -1038,6 +1039,57 @@ if (import.meta.vitest) {
 			type A = DefaultAdapter
 			type Ref = import('./builders').SchemaRefSurface<import('../schema').AnySchema, A>
 			expectTypeOf<Ref['aggregate']>().toBeNever()
+		})
+	})
+
+	describe('type-level: AggregateBuilder', () => {
+		class AggAdapter extends OrmAdapter {
+			readonly schemaConfigPipe = v.object({})
+			readonly supportedFieldTypes = ['string', 'number'] as const
+			readonly aggregateOps = ['count'] as const
+			async aggregate() { return [] }
+		}
+		const _S = Schema.from('items')
+			.pk('id', v.string(), () => 'x')
+			.field('name', v.string())
+			.field('amount', v.number())
+			.build()
+		type S = typeof _S
+		type A = AggAdapter
+		type Builder = import('./builders').AggregateBuilder<S, A, {}, false>
+
+		test('.count(alias) adds alias to result type as number', () => {
+			type AfterCount = ReturnType<Builder['count']>
+			type Result = Awaited<ReturnType<AfterCount['run']>>
+			expectTypeOf<Result>().toHaveProperty('total')
+		})
+
+		test('duplicate alias: "a" extends keyof Aggs triggers never guard', () => {
+			type AggsWithA = { a: number }
+			type DuplicateGuard = 'a' extends keyof AggsWithA ? [never] : [alias: 'a']
+			expectTypeOf<DuplicateGuard>().toEqualTypeOf<[never]>()
+		})
+
+		test('.run() on empty Aggs requires never arg (compile error gate)', () => {
+			type RunParams = Parameters<Builder['run']>
+			expectTypeOf<RunParams>().toEqualTypeOf<[never]>()
+		})
+
+		test('.run() on non-empty Aggs takes no args', () => {
+			type WithCount = import('./builders').AggregateBuilder<S, A, { total: number }, false>
+			type RunParams = Parameters<WithCount['run']>
+			expectTypeOf<RunParams>().toEqualTypeOf<[]>()
+		})
+
+		test('.run() returns single object when HasGroupBy = false', () => {
+			type WithCount = import('./builders').AggregateBuilder<S, A, { total: number }, false>
+			type Result = Awaited<ReturnType<WithCount['run']>>
+			expectTypeOf<Result>().toEqualTypeOf<{ total: number }>()
+		})
+
+		test('clone-on-step: .where() returns a new builder', () => {
+			type After = ReturnType<Builder['where']>
+			expectTypeOf<After>().toMatchTypeOf<Builder>()
 		})
 	})
 
@@ -2073,6 +2125,86 @@ if (import.meta.vitest) {
 
 			const found = await repo.on(TestSchema).one().id(user.id).find()
 			expect(found).toBeNull()
+		})
+	})
+
+	describe('repo.on().aggregate() end-to-end', () => {
+		const OrderSchema = Schema.from('orders')
+			.pk('id', v.string(), () => `o-${Math.random().toString(36).slice(2, 8)}`)
+			.field('product', v.string())
+			.field('amount', v.number())
+			.field('region', v.string())
+			.build()
+
+		function makeAggRepo() {
+			const adapter = InMemoryAdapter.create({})
+			const repo = Repo.from(adapter).resolve((s) => ({ table: s.name })).build()
+			return { repo, adapter }
+		}
+
+		async function seedOrders(repo: any) {
+			await repo.on(OrderSchema).all().create([
+				{ product: 'Widget', amount: 10, region: 'US' },
+				{ product: 'Gadget', amount: 20, region: 'EU' },
+				{ product: 'Widget', amount: 30, region: 'US' },
+				{ product: 'Gadget', amount: 40, region: 'EU' },
+				{ product: 'Widget', amount: 50, region: 'US' },
+			])
+		}
+
+		test('count returns total row count', async () => {
+			const { repo } = makeAggRepo()
+			await seedOrders(repo)
+			const result = await repo.on(OrderSchema).aggregate().count('total').run()
+			expect(result).toEqual({ total: 5 })
+		})
+
+		test('count with where filter returns filtered count', async () => {
+			const { repo } = makeAggRepo()
+			await seedOrders(repo)
+			const result = await repo
+				.on(OrderSchema)
+				.aggregate()
+				.where((q) => q.eq('region', 'US'))
+				.count('total')
+				.run()
+			expect(result).toEqual({ total: 3 })
+		})
+
+		test('count on empty result returns zero', async () => {
+			const { repo } = makeAggRepo()
+			const result = await repo.on(OrderSchema).aggregate().count('total').run()
+			expect(result).toEqual({ total: 0 })
+		})
+
+		test('clone-on-step: base builder is not mutated by fan-out', async () => {
+			const { repo } = makeAggRepo()
+			await seedOrders(repo)
+			const base = repo.on(OrderSchema).aggregate().count('a')
+			const withFilter = base.where((q) => q.eq('region', 'US'))
+			const resultAll = await base.count('b').run()
+			const resultFiltered = await withFilter.count('c').run()
+			expect(resultAll.a).toBe(5)
+			expect(resultFiltered.a).toBe(3)
+		})
+
+		test('where before count produces correct result', async () => {
+			const { repo } = makeAggRepo()
+			await seedOrders(repo)
+			const result = await repo
+				.on(OrderSchema)
+				.aggregate()
+				.count('total')
+				.where((q) => q.eq('product', 'Gadget'))
+				.run()
+			expect(result).toEqual({ total: 2 })
+		})
+
+		test('boundary validation rejects unknown field in where filter', async () => {
+			const { repo } = makeAggRepo()
+			await expect(
+				repo.on(OrderSchema).aggregate().count('total').where((q) => q.eq('nonexistent', 'x')).run(),
+			).rejects.toThrow(OrmValidationError)
 		})
 	})
 


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #76.

Closes #76

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._