### PR TITLE
Sandcastle: V1: Migrate v.assert call sites to inline v.validate (package-wide ban) (#98)

### DIFF
--- a/src/orm/repo/internals/computeds.ts
+++ b/src/orm/repo/internals/computeds.ts
@@ -79,7 +79,13 @@ export function applyComputedSelection(
 				}
 				depInput[dep] = row[dep]
 			}
-			enriched[computeName] = v.assert(def.pipe, def.compute(depInput))
+			const r = v.validate(def.pipe, def.compute(depInput))
+			if (!r.valid) throw new EquippedError('Computed field validation failed', {
+				schema: schema.name,
+				computedField: computeName,
+				cause: r.error,
+			})
+			enriched[computeName] = r.value
 		}
 
 		if (!plan.requestedSelect) return enriched

--- a/src/orm/schema-validations.ts
+++ b/src/orm/schema-validations.ts
@@ -93,7 +93,9 @@ export function validateUpdate<S extends AnySchema>(s: S, data: Record<string, u
 		if (!(key in data) && entry.onUpdate) pipes[key] = v.defaults(entry.pipe, entry.onUpdate())
 	}
 
-	const validated = v.assert(v.object(pipes), data) as Record<string, unknown>
+	const r = v.validate(v.object(pipes), data)
+	if (!r.valid) throw new OrmValidationError('validation', s.name, 'updateByPk', [{ cause: r.error }])
+	const validated = r.value as Record<string, unknown>
 	return { ...validated, ...ops } as SchemaUpdateOutput<S>
 }
 
@@ -135,10 +137,9 @@ export function validateUpdateOps(schema: AnySchema, ops: AnyUpdateOp[], operati
 			for (const [key, value] of Object.entries(op.values)) {
 				const fieldDef = schema.fields[key] as AnySchemaField | undefined
 				if (!fieldDef) continue
-				try {
-					v.assert(fieldDef.pipe, value)
-				} catch (cause) {
-					failures.push({ opIndex: i, field: key, cause })
+				const r = v.validate(fieldDef.pipe, value)
+				if (!r.valid) {
+					failures.push({ opIndex: i, field: key, cause: r.error })
 				}
 			}
 		}
@@ -160,11 +161,9 @@ export function composeSchemaConfig(
 	for (const transform of transforms) {
 		config = transform(config, schema)
 	}
-	try {
-		return v.assert(pipe, config)
-	} catch (cause) {
-		throw new OrmValidationError('validation', schema.name, 'schemaConfig', [{ cause }])
-	}
+	const r = v.validate(pipe, config)
+	if (!r.valid) throw new OrmValidationError('validation', schema.name, 'schemaConfig', [{ cause: r.error }])
+	return r.value
 }
 
 export function validateUpsertConflicts(

--- a/src/server/adapters/base.ts
+++ b/src/server/adapters/base.ts
@@ -247,7 +247,9 @@ export abstract class Server {
 				responsePipeDefs[def.key] = v.any().pipe((input) => {
 					const p = pipeRecords.find((r) => r.status === status)?.pipe
 					if (!p) throw PipeError.root(`schema not defined for status code: ${status}`, input)
-					return v.assert(p, input)
+					const r = v.validate(p, input)
+					if (!r.valid) throw r.error
+					return r.value
 				})
 				jsonSchema.response[def.key as keyof typeof jsonSchema.response] = pipeRecords.map((record) => ({
 					status: record.status,

--- a/src/server/adapters/base.ts
+++ b/src/server/adapters/base.ts
@@ -245,7 +245,7 @@ export abstract class Server {
 			if (def.type === 'response') {
 				const pipeRecords = errorsSchemas.concat({ status: defaultStatusCode, contentType, pipe })
 				responsePipeDefs[def.key] = v.any().pipe((input) => {
-					const p = pipeRecords.find((r) => r.status === status)?.pipe
+					const p = pipeRecords.find((rec) => rec.status === status)?.pipe
 					if (!p) throw PipeError.root(`schema not defined for status code: ${status}`, input)
 					const r = v.validate(p, input)
 					if (!r.valid) throw r.error

--- a/src/utilities/configurable.ts
+++ b/src/utilities/configurable.ts
@@ -22,8 +22,7 @@ export function configurable<P extends Pipe<any, any>, Base extends abstract new
 		): This['prototype'] {
 			const r = v.validate(pipe, input)
 			if (!r.valid) throw r.error
-			const validated = r.value
-			return new (this as any)(validated, ...args) as This['prototype']
+			return new (this as any)(r.value, ...args) as This['prototype']
 		}
 	}
 

--- a/src/utilities/configurable.ts
+++ b/src/utilities/configurable.ts
@@ -20,7 +20,9 @@ export function configurable<P extends Pipe<any, any>, Base extends abstract new
 			input: ConditionalObjectKeys<PipeInput<P>>,
 			...args: CtorParams<This> extends [PipeOutput<P>, ...infer R] ? R : never
 		): This['prototype'] {
-			const validated = v.assert(pipe, input)
+			const r = v.validate(pipe, input)
+			if (!r.valid) throw r.error
+			const validated = r.value
 			return new (this as any)(validated, ...args) as This['prototype']
 		}
 	}


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #98.

Closes #98

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._