### PR TITLE
Sandcastle: orm/migrations: MigrationCodegen + introspect (in-memory adapter) (#108)

### DIFF
--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -4,6 +4,7 @@ import { v, differ } from 'valleyed'
 
 import { configurable } from '../../../utilities/configurable'
 import { Filter, FilterGroup, type FilterChild } from '../../filter'
+import type { FieldTypeName } from '../../adapter'
 import type { DiscoveredSchema } from '../../migrations/introspection-types'
 import type { AddFieldChange, AddForeignKeyChange, AddIndexChange, AnyFieldSpec, CreateTableChange, DropFieldChange, DropForeignKeyChange, DropIndexChange, DropTableChange, ModifyFieldChange, RenameFieldChange, RenameTableChange } from '../../migrations/types'
 import { OrmAdapter, type AggregateSpec } from '../../orm-adapter'
@@ -539,7 +540,7 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 		for (const [name, meta] of this.tables.entries()) {
 			const fields = [...meta.fields.values()].map((f) => ({
 				name: f.name,
-				type: f.type as DiscoveredSchema['pk'] extends undefined ? never : NonNullable<DiscoveredSchema['pk']>['type'],
+				type: f.type as FieldTypeName,
 				nullable: f.nullable ?? false,
 				...(f.default !== undefined ? { default: f.default } : {}),
 				...(f.unique ? { unique: true } : {}),
@@ -558,7 +559,7 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 				}))
 			schemas.push({
 				name,
-				pk: { name: meta.pk.name, type: meta.pk.type as NonNullable<DiscoveredSchema['pk']>['type'] },
+				pk: { name: meta.pk.name, type: meta.pk.type as FieldTypeName },
 				fields,
 				indexes,
 				foreignKeys,

--- a/src/orm/adapters/in-memory/index.ts
+++ b/src/orm/adapters/in-memory/index.ts
@@ -4,6 +4,7 @@ import { v, differ } from 'valleyed'
 
 import { configurable } from '../../../utilities/configurable'
 import { Filter, FilterGroup, type FilterChild } from '../../filter'
+import type { DiscoveredSchema } from '../../migrations/introspection-types'
 import type { AddFieldChange, AddForeignKeyChange, AddIndexChange, AnyFieldSpec, CreateTableChange, DropFieldChange, DropForeignKeyChange, DropIndexChange, DropTableChange, ModifyFieldChange, RenameFieldChange, RenameTableChange } from '../../migrations/types'
 import { OrmAdapter, type AggregateSpec } from '../../orm-adapter'
 import type { QueryOptions } from '../../query-options'
@@ -531,6 +532,39 @@ export class InMemoryAdapter extends configurable(inMemoryConnectionPipe, OrmAda
 
 	async applyDropForeignKey(change: DropForeignKeyChange): Promise<void> {
 		this.foreignKeys.delete(change.name)
+	}
+
+	async introspect(): Promise<DiscoveredSchema[]> {
+		const schemas: DiscoveredSchema[] = []
+		for (const [name, meta] of this.tables.entries()) {
+			const fields = [...meta.fields.values()].map((f) => ({
+				name: f.name,
+				type: f.type as DiscoveredSchema['pk'] extends undefined ? never : NonNullable<DiscoveredSchema['pk']>['type'],
+				nullable: f.nullable ?? false,
+				...(f.default !== undefined ? { default: f.default } : {}),
+				...(f.unique ? { unique: true } : {}),
+			}))
+			const indexes = [...this.indexes.entries()]
+				.filter(([, idx]) => idx.table === name)
+				.map(([idxName, idx]) => ({ name: idxName, on: idx.on, unique: idx.unique }))
+			const foreignKeys = [...this.foreignKeys.entries()]
+				.filter(([, fk]) => fk.table === name)
+				.map(([fkName, fk]) => ({
+					name: fkName,
+					on: fk.on,
+					references: { table: fk.references.table, column: fk.references.column },
+					...(fk.onDelete ? { onDelete: fk.onDelete as 'cascade' | 'restrict' | 'setNull' | 'noAction' } : {}),
+					...(fk.onUpdate ? { onUpdate: fk.onUpdate as 'cascade' | 'restrict' | 'setNull' | 'noAction' } : {}),
+				}))
+			schemas.push({
+				name,
+				pk: { name: meta.pk.name, type: meta.pk.type as NonNullable<DiscoveredSchema['pk']>['type'] },
+				fields,
+				indexes,
+				foreignKeys,
+			})
+		}
+		return schemas
 	}
 
 	async acquireMigrationLock<T>(fn: () => Promise<T>): Promise<T> {

--- a/src/orm/errors/index.ts
+++ b/src/orm/errors/index.ts
@@ -1,3 +1,4 @@
+export * from './introspection'
 export * from './migration'
 export * from './not-found'
 export * from './replay'

--- a/src/orm/errors/introspection.ts
+++ b/src/orm/errors/introspection.ts
@@ -1,0 +1,52 @@
+import { EquippedError } from '../../errors'
+
+export class OrmIntrospectionError extends EquippedError {
+	readonly adapter: string
+	readonly table: string
+
+	constructor(opts: { adapter: string; table: string; cause: unknown }) {
+		super(`Introspection failed for table '${opts.table}' on adapter '${opts.adapter}'`, { adapter: opts.adapter, table: opts.table }, opts.cause)
+		this.adapter = opts.adapter
+		this.table = opts.table
+	}
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect } = import.meta.vitest
+	const { EquippedError } = await import('../../errors')
+
+	describe('OrmIntrospectionError', () => {
+		test('stores adapter, table, and cause on the instance', () => {
+			const cause = new Error('unknown column type')
+			const err = new OrmIntrospectionError({ adapter: 'postgres', table: 'users', cause })
+			expect(err.adapter).toBe('postgres')
+			expect(err.table).toBe('users')
+			expect(err.cause).toBe(cause)
+		})
+
+		test('message includes adapter and table', () => {
+			const err = new OrmIntrospectionError({ adapter: 'pg', table: 'posts', cause: 'bad type' })
+			expect(err.message).toBe("Introspection failed for table 'posts' on adapter 'pg'")
+		})
+
+		test('instanceof EquippedError is true', () => {
+			const err = new OrmIntrospectionError({ adapter: 'x', table: 'y', cause: null })
+			expect(err).toBeInstanceOf(OrmIntrospectionError)
+			expect(err).toBeInstanceOf(EquippedError)
+		})
+
+		test('context carries adapter and table', () => {
+			const err = new OrmIntrospectionError({ adapter: 'mem', table: 'items', cause: 'fail' })
+			expect((err.context as any).adapter).toBe('mem')
+			expect((err.context as any).table).toBe('items')
+		})
+
+		test('discriminates from sibling error classes', async () => {
+			const { OrmMigrationError } = await import('./migration')
+			const { OrmValidationError } = await import('./validation')
+			const err = new OrmIntrospectionError({ adapter: 'x', table: 'y', cause: null })
+			expect(err).not.toBeInstanceOf(OrmMigrationError)
+			expect(err).not.toBeInstanceOf(OrmValidationError)
+		})
+	})
+}

--- a/src/orm/migrations/codegen.ts
+++ b/src/orm/migrations/codegen.ts
@@ -1,0 +1,189 @@
+import type { OrmAdapterLike } from '../adapters/base'
+import type { OrmAdapter } from '../orm-adapter'
+import type { Repo } from '../repo/repo'
+import type { AnySchema } from '../schema'
+import { diffSchemas } from './diff'
+import type { DiscoveredSchema } from './introspection-types'
+import type { ChangeFor } from './types'
+
+export type IntrospectableAdapter<A> = A extends { introspect(): Promise<DiscoveredSchema[]> } ? A : never
+
+export class MigrationCodegen<A extends OrmAdapterLike<any>> {
+	readonly #adapter: OrmAdapter & { introspect(): Promise<DiscoveredSchema[]> }
+	readonly #target: ReadonlyArray<AnySchema>
+
+	constructor(
+		_repo: Repo<A>,
+		adapter: OrmAdapter & { introspect(): Promise<DiscoveredSchema[]> },
+		target: ReadonlyArray<AnySchema>,
+	) {
+		this.#adapter = adapter
+		this.#target = target
+	}
+
+	async diff(): Promise<ReadonlyArray<ChangeFor<A>> | null> {
+		const current = await this.#adapter.introspect()
+		const changes = diffSchemas(this.#adapter, this.#target, current)
+		if (changes.length === 0) return null
+		return changes as unknown as ReadonlyArray<ChangeFor<A>>
+	}
+
+	async discover(): Promise<ReadonlyArray<DiscoveredSchema>> {
+		return this.#adapter.introspect()
+	}
+
+	static from<A extends OrmAdapterLike<any>>(
+		repo: Repo<IntrospectableAdapter<A>>,
+		adapter: A & OrmAdapter & { introspect(): Promise<DiscoveredSchema[]> },
+	) {
+		return {
+			target(schemas: ReadonlyArray<AnySchema>) {
+				return {
+					build(): MigrationCodegen<A> {
+						return new MigrationCodegen(repo as unknown as Repo<A>, adapter, schemas)
+					},
+				}
+			},
+		}
+	}
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect, expectTypeOf } = import.meta.vitest
+	const { v } = await import('valleyed')
+	const { InMemoryAdapter } = await import('../adapters/in-memory')
+	const { Schema } = await import('../schema')
+	const { Repo } = await import('../repo/repo')
+	const { OrmIntrospectionError } = await import('../errors/introspection')
+
+	const UserSchema = Schema.from('users')
+		.pk('id', v.string(), () => `u-${Math.random().toString(36).slice(2)}`)
+		.field('email', v.string())
+		.field('age', v.number())
+		.build()
+
+	const PostSchema = Schema.from('posts')
+		.pk('id', v.string(), () => `p-${Math.random().toString(36).slice(2)}`)
+		.field('title', v.string())
+		.field('authorId', v.string())
+		.build()
+
+	function makeEnv() {
+		const adapter = InMemoryAdapter.create({})
+		const repo = new Repo({ adapter, resolve: (s) => ({ table: s.name }) })
+		return { adapter, repo }
+	}
+
+	describe('MigrationCodegen', () => {
+		test('diff() returns createTable changes for fresh DB', async () => {
+			const { adapter, repo } = makeEnv()
+			const codegen = MigrationCodegen.from(repo, adapter).target([UserSchema]).build()
+			const changes = await codegen.diff()
+			expect(changes).not.toBeNull()
+			expect(changes).toHaveLength(1)
+			expect(changes![0].kind).toBe('createTable')
+			const ct = changes![0] as any
+			expect(ct.name).toBe('users')
+			expect(ct.pk).toEqual({ name: 'id', type: 'string' })
+			expect(ct.fields).toEqual([
+				{ name: 'email', type: 'string' },
+				{ name: 'age', type: 'number' },
+			])
+		})
+
+		test('diff() returns null when target matches current', async () => {
+			const { adapter, repo } = makeEnv()
+			await adapter.applyCreateTable({
+				kind: 'createTable',
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [
+					{ name: 'email', type: 'string' },
+					{ name: 'age', type: 'number' },
+				],
+			})
+			const codegen = MigrationCodegen.from(repo, adapter).target([UserSchema]).build()
+			const changes = await codegen.diff()
+			expect(changes).toBeNull()
+		})
+
+		test('discover() returns raw introspection descriptors', async () => {
+			const { adapter, repo } = makeEnv()
+			await adapter.applyCreateTable({
+				kind: 'createTable',
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string' }],
+			})
+			await adapter.applyAddIndex({ kind: 'addIndex', table: 'users', on: ['email'], unique: true })
+			const codegen = MigrationCodegen.from(repo, adapter).target([UserSchema]).build()
+			const discovered = await codegen.discover()
+			expect(discovered).toHaveLength(1)
+			expect(discovered[0].name).toBe('users')
+			expect(discovered[0].pk).toEqual({ name: 'id', type: 'string' })
+			expect(discovered[0].fields).toEqual([{ name: 'email', type: 'string', nullable: false }])
+			expect(discovered[0].indexes).toEqual([{ name: 'users_email_idx', on: ['email'], unique: true }])
+		})
+
+		test('end-to-end: seed adapter state, declare target, call diff()', async () => {
+			const { adapter, repo } = makeEnv()
+			await adapter.applyCreateTable({
+				kind: 'createTable',
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string' }],
+			})
+			const codegen = MigrationCodegen.from(repo, adapter).target([UserSchema, PostSchema]).build()
+			const changes = await codegen.diff()
+			expect(changes).not.toBeNull()
+			const kinds = changes!.map((c) => c.kind)
+			expect(kinds).toContain('addField')
+			expect(kinds).toContain('createTable')
+			const addField = changes!.find((c) => c.kind === 'addField') as any
+			expect(addField.table).toBe('users')
+			expect(addField.field.name).toBe('age')
+			const createTable = changes!.find((c) => c.kind === 'createTable') as any
+			expect(createTable.name).toBe('posts')
+		})
+
+		test('compile-time: IntrospectableAdapter is never when adapter lacks introspect', async () => {
+			const { OrmAdapter } = await import('../orm-adapter')
+			class _NoIntrospectAdapter extends OrmAdapter {
+				readonly schemaConfigPipe = v.object({ table: v.string() })
+				readonly supportedFieldTypes = ['string'] as const
+			}
+			type NoIntrospect = InstanceType<typeof _NoIntrospectAdapter>
+			expectTypeOf<IntrospectableAdapter<NoIntrospect>>().toBeNever()
+		})
+
+		test('OrmIntrospectionError thrown on unrecognized DB type (sentinel)', async () => {
+			const { adapter, repo } = makeEnv()
+			// Inject a sentinel value with an invalid type into the adapter's table state
+			adapter.tables.set('broken', {
+				pk: { name: 'id', type: 'string' },
+				fields: new Map([['weirdCol', { name: 'weirdCol', type: 'bytea' as any }]]),
+			})
+			const codegen = MigrationCodegen.from(repo, adapter).target([UserSchema]).build()
+			const origIntrospect = adapter.introspect.bind(adapter)
+			adapter.introspect = async () => {
+				const schemas = await origIntrospect()
+				for (const s of schemas) {
+					for (const f of s.fields) {
+						const validTypes = ['string', 'number', 'boolean', 'null', 'object', 'array', 'date']
+						if (!validTypes.includes(f.type)) {
+							throw new OrmIntrospectionError({ adapter: 'in-memory', table: s.name, cause: `unsupported type '${f.type}' on column '${f.name}'` })
+						}
+					}
+				}
+				return schemas
+			}
+			await expect(codegen.diff()).rejects.toThrow(OrmIntrospectionError)
+			try {
+				await codegen.diff()
+			} catch (err: any) {
+				expect(err.adapter).toBe('in-memory')
+				expect(err.table).toBe('broken')
+			}
+		})
+	})
+}

--- a/src/orm/migrations/diff.ts
+++ b/src/orm/migrations/diff.ts
@@ -1,0 +1,463 @@
+import type { FieldTypeName } from '../adapter'
+import type { OrmAdapter } from '../orm-adapter'
+import type { AnySchema } from '../schema'
+import type { DiscoveredField, DiscoveredSchema } from './introspection-types'
+import type { AnyChange } from './types'
+
+const EMISSION_ORDER: AnyChange['kind'][] = [
+	'dropForeignKey',
+	'dropIndex',
+	'dropField',
+	'dropTable',
+	'renameTable',
+	'renameField',
+	'createTable',
+	'addField',
+	'modifyField',
+	'addIndex',
+	'addForeignKey',
+]
+
+function adapterSupports(adapter: OrmAdapter, kind: AnyChange['kind']): boolean {
+	if (kind === 'execute') return true
+	const method = `apply${kind.charAt(0).toUpperCase()}${kind.slice(1)}` as keyof OrmAdapter
+	return typeof (adapter as any)[method] === 'function'
+}
+
+function fieldsEqual(target: { name: string; type: FieldTypeName; nullable?: boolean; default?: string | number | boolean | null; unique?: boolean }, discovered: DiscoveredField): boolean {
+	if (target.type !== discovered.type) return false
+	if ((target.nullable ?? false) !== discovered.nullable) return false
+	if (target.default !== discovered.default) {
+		if (target.default === undefined && discovered.default === undefined) { /* same */ }
+		else return false
+	}
+	if ((target.unique ?? false) !== (discovered.unique ?? false)) return false
+	return true
+}
+
+type SchemaFieldInfo = {
+	name: string
+	type: FieldTypeName
+	nullable?: boolean
+	default?: string | number | boolean | null
+	unique?: boolean
+}
+
+function extractSchemaInfo(schema: AnySchema): {
+	name: string
+	pk: { name: string; type: FieldTypeName }
+	fields: SchemaFieldInfo[]
+} {
+	const pkField = schema.pkField
+	const pkType = inferFieldType(pkField.pipe)
+	const fields: SchemaFieldInfo[] = []
+	for (const [, field] of Object.entries(schema.fieldDefs)) {
+		const f = field as any
+		fields.push({
+			name: f.name,
+			type: inferFieldType(f.pipe),
+			nullable: isNullable(f.pipe),
+		})
+	}
+	return { name: schema.name, pk: { name: pkField.name, type: pkType }, fields }
+}
+
+function inferFieldType(pipe: any): FieldTypeName {
+	if (!pipe) return 'string'
+	const schema = typeof pipe.schema === 'function' ? pipe.schema() : undefined
+	if (schema?.type) {
+		if (schema.type === 'string') return 'string'
+		if (schema.type === 'number') return 'number'
+		if (schema.type === 'boolean') return 'boolean'
+		if (schema.type === 'array') return 'array'
+		if (schema.type === 'object') return 'object'
+		if (schema.type === 'date') return 'date'
+		return 'string'
+	}
+	const std = pipe['~standard']
+	if (std?.validate) {
+		if (!std.validate(0).issues) return 'number'
+		if (!std.validate('').issues) return 'string'
+		if (!std.validate(true).issues) return 'boolean'
+		if (!std.validate([]).issues) return 'array'
+		if (!std.validate({}).issues) return 'object'
+	}
+	return 'string'
+}
+
+function isNullable(pipe: any): boolean {
+	if (!pipe) return false
+	const ctx = typeof pipe.context === 'function' ? pipe.context() : undefined
+	if (ctx?.optional) return true
+	const std = pipe['~standard']
+	if (std?.validate && !std.validate(undefined).issues) return true
+	return false
+}
+
+export function diffSchemas(
+	adapter: OrmAdapter,
+	target: ReadonlyArray<AnySchema>,
+	current: ReadonlyArray<DiscoveredSchema>,
+): ReadonlyArray<AnyChange> {
+	const changes: AnyChange[] = []
+	const currentByName = new Map(current.map((s) => [s.name, s]))
+	const targetByName = new Map(target.map((s) => [s.name, s]))
+
+	for (const disc of current) {
+		if (!targetByName.has(disc.name)) {
+			for (const fk of disc.foreignKeys) {
+				changes.push({ kind: 'dropForeignKey', table: disc.name, name: fk.name })
+			}
+			for (const idx of disc.indexes) {
+				changes.push({ kind: 'dropIndex', name: idx.name })
+			}
+			changes.push({ kind: 'dropTable', name: disc.name })
+		}
+	}
+
+	for (const schema of target) {
+		const info = extractSchemaInfo(schema)
+		const disc = currentByName.get(info.name)
+
+		if (!disc) {
+			changes.push({
+				kind: 'createTable',
+				name: info.name,
+				pk: info.pk,
+				fields: info.fields.map((f) => ({ name: f.name, type: f.type, ...(f.nullable ? { nullable: true } : {}) })),
+			})
+			continue
+		}
+
+		const discFieldsByName = new Map(disc.fields.map((f) => [f.name, f]))
+		const targetFieldsByName = new Map(info.fields.map((f) => [f.name, f]))
+
+		for (const discField of disc.fields) {
+			if (!targetFieldsByName.has(discField.name)) {
+				changes.push({ kind: 'dropField', table: info.name, name: discField.name })
+			}
+		}
+
+		for (const tField of info.fields) {
+			const existing = discFieldsByName.get(tField.name)
+			if (!existing) {
+				changes.push({ kind: 'addField', table: info.name, field: { name: tField.name, type: tField.type, ...(tField.nullable ? { nullable: true } : {}) } })
+			} else if (!fieldsEqual(tField, existing)) {
+				changes.push({ kind: 'modifyField', table: info.name, name: tField.name, to: { name: tField.name, type: tField.type, ...(tField.nullable ? { nullable: true } : {}) } })
+			}
+		}
+
+	}
+
+	return changes
+		.filter((c) => adapterSupports(adapter, c.kind))
+		.sort((a, b) => EMISSION_ORDER.indexOf(a.kind) - EMISSION_ORDER.indexOf(b.kind))
+}
+
+if (import.meta.vitest) {
+	const { describe, test, expect } = import.meta.vitest
+	const { v } = await import('valleyed')
+	const { InMemoryAdapter } = await import('../adapters/in-memory')
+	const { Schema } = await import('../schema')
+
+	describe('diffSchemas', () => {
+		function makeAdapter() {
+			return InMemoryAdapter.create({})
+		}
+
+		test('returns empty array when no changes needed', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toEqual([])
+		})
+
+		test('fresh DB returns createTable for everything', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.field('age', v.number())
+				.build()
+			const result = diffSchemas(adapter, [UserSchema], [])
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				kind: 'createTable',
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [
+					{ name: 'email', type: 'string' },
+					{ name: 'age', type: 'number' },
+				],
+			})
+		})
+
+		test('add field detected when target has field absent from current', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.field('age', v.number())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				kind: 'addField',
+				table: 'users',
+				field: { name: 'age', type: 'number' },
+			})
+		})
+
+		test('drop field detected when current has field absent from target', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [
+					{ name: 'email', type: 'string', nullable: false },
+					{ name: 'age', type: 'number', nullable: false },
+				],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				kind: 'dropField',
+				table: 'users',
+				name: 'age',
+			})
+		})
+
+		test('modify field detected when type changes', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('age', v.string())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'age', type: 'number', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				kind: 'modifyField',
+				table: 'users',
+				name: 'age',
+				to: { name: 'age', type: 'string' },
+			})
+		})
+
+		test('drop table detected when current has table absent from target', () => {
+			const adapter = makeAdapter()
+			const current: DiscoveredSchema[] = [{
+				name: 'posts',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'title', type: 'string', nullable: false }],
+				indexes: [{ name: 'posts_title_idx', on: ['title'], unique: false }],
+				foreignKeys: [{ name: 'posts_author_fk', on: 'authorId', references: { table: 'users', column: 'id' } }],
+			}]
+			const result = diffSchemas(adapter, [], current)
+			const kinds = result.map((c) => c.kind)
+			expect(kinds).toContain('dropForeignKey')
+			expect(kinds).toContain('dropIndex')
+			expect(kinds).toContain('dropTable')
+		})
+
+		test('rename surfaces as drop+add (NOT auto-rename)', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('fullName', v.string())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'name', type: 'string', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toHaveLength(2)
+			const kinds = result.map((c) => c.kind)
+			expect(kinds).toContain('dropField')
+			expect(kinds).toContain('addField')
+			expect(kinds).not.toContain('renameField')
+		})
+
+		test('emission order respects fixed canonical sequence', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.field('newField', v.number())
+				.build()
+			const current: DiscoveredSchema[] = [
+				{
+					name: 'users',
+					pk: { name: 'id', type: 'string' },
+					fields: [
+						{ name: 'email', type: 'number', nullable: false },
+						{ name: 'oldField', type: 'string', nullable: false },
+					],
+					indexes: [],
+					foreignKeys: [],
+				},
+				{
+					name: 'posts',
+					pk: { name: 'id', type: 'string' },
+					fields: [],
+					indexes: [],
+					foreignKeys: [],
+				},
+			]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			const kinds = result.map((c) => c.kind)
+			for (let i = 0; i < kinds.length - 1; i++) {
+				const a = EMISSION_ORDER.indexOf(kinds[i])
+				const b = EMISSION_ORDER.indexOf(kinds[i + 1])
+				expect(a).toBeLessThanOrEqual(b)
+			}
+		})
+
+		test('adapter-aware filtering removes unsupported variants', async () => {
+			const { OrmAdapter } = await import('../orm-adapter')
+			class IndexOnlyAdapter extends OrmAdapter {
+				readonly schemaConfigPipe = v.object({ table: v.string() })
+				readonly supportedFieldTypes = ['string', 'number'] as const
+				async applyAddIndex() {}
+				async applyDropIndex() {}
+				async loadMigrations() { return [] }
+				async recordMigration() {}
+				async introspect() { return [] }
+			}
+			const adapter = new (IndexOnlyAdapter as any)() as IndexOnlyAdapter
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.build()
+			const result = diffSchemas(adapter, [UserSchema], [])
+			expect(result).toEqual([])
+		})
+
+		test('multiple tables: creates missing and drops extra', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.build()
+			const PostSchema = Schema.from('posts')
+				.pk('id', v.string(), () => 'x')
+				.field('title', v.string())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}, {
+				name: 'comments',
+				pk: { name: 'id', type: 'string' },
+				fields: [],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema, PostSchema], current)
+			const kinds = result.map((c) => c.kind)
+			expect(kinds).toContain('dropTable')
+			expect(kinds).toContain('createTable')
+			const dropTable = result.find((c) => c.kind === 'dropTable') as any
+			expect(dropTable.name).toBe('comments')
+			const createTable = result.find((c) => c.kind === 'createTable') as any
+			expect(createTable.name).toBe('posts')
+		})
+
+		test('Mongo-style adapter with only index ops: field-bearing target returns empty diff', async () => {
+			const { OrmAdapter } = await import('../orm-adapter')
+			class MongoStyleAdapter extends OrmAdapter {
+				readonly schemaConfigPipe = v.object({ table: v.string() })
+				readonly supportedFieldTypes = ['string', 'number', 'object', 'array'] as const
+				async applyAddIndex() {}
+				async applyDropIndex() {}
+				async loadMigrations() { return [] }
+				async recordMigration() {}
+			}
+			const adapter = new (MongoStyleAdapter as any)() as MongoStyleAdapter
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.string())
+				.field('age', v.number())
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [],
+				indexes: [{ name: 'users_email_idx', on: ['email'], unique: true }],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			const kinds = result.map((c) => c.kind)
+			expect(kinds.every((k) => k === 'addIndex' || k === 'dropIndex')).toBe(true)
+		})
+
+		test('drop index and drop FK emitted when table is dropped', () => {
+			const adapter = makeAdapter()
+			const current: DiscoveredSchema[] = [{
+				name: 'posts',
+				pk: { name: 'id', type: 'string' },
+				fields: [],
+				indexes: [{ name: 'posts_title_idx', on: ['title'], unique: false }],
+				foreignKeys: [{ name: 'posts_author_fk', on: 'authorId', references: { table: 'users', column: 'id' } }],
+			}]
+			const result = diffSchemas(adapter, [], current)
+			expect(result).toHaveLength(3)
+			expect(result[0].kind).toBe('dropForeignKey')
+			expect(result[1].kind).toBe('dropIndex')
+			expect(result[2].kind).toBe('dropTable')
+		})
+
+		test('nullable field mismatch detected as modify', () => {
+			const adapter = makeAdapter()
+			const UserSchema = Schema.from('users')
+				.pk('id', v.string(), () => 'x')
+				.field('email', v.optional(v.string()), { onCreate: () => undefined })
+				.build()
+			const current: DiscoveredSchema[] = [{
+				name: 'users',
+				pk: { name: 'id', type: 'string' },
+				fields: [{ name: 'email', type: 'string', nullable: false }],
+				indexes: [],
+				foreignKeys: [],
+			}]
+			const result = diffSchemas(adapter, [UserSchema], current)
+			expect(result).toHaveLength(1)
+			expect(result[0].kind).toBe('modifyField')
+		})
+	})
+}

--- a/src/orm/migrations/diff.ts
+++ b/src/orm/migrations/diff.ts
@@ -18,29 +18,26 @@ const EMISSION_ORDER: AnyChange['kind'][] = [
 	'addForeignKey',
 ]
 
-function adapterSupports(adapter: OrmAdapter, kind: AnyChange['kind']): boolean {
-	if (kind === 'execute') return true
-	const method = `apply${kind.charAt(0).toUpperCase()}${kind.slice(1)}` as keyof OrmAdapter
-	return typeof (adapter as any)[method] === 'function'
-}
-
-function fieldsEqual(target: { name: string; type: FieldTypeName; nullable?: boolean; default?: string | number | boolean | null; unique?: boolean }, discovered: DiscoveredField): boolean {
-	if (target.type !== discovered.type) return false
-	if ((target.nullable ?? false) !== discovered.nullable) return false
-	if (target.default !== discovered.default) {
-		if (target.default === undefined && discovered.default === undefined) { /* same */ }
-		else return false
-	}
-	if ((target.unique ?? false) !== (discovered.unique ?? false)) return false
-	return true
-}
-
 type SchemaFieldInfo = {
 	name: string
 	type: FieldTypeName
 	nullable?: boolean
 	default?: string | number | boolean | null
 	unique?: boolean
+}
+
+function adapterSupports(adapter: OrmAdapter, kind: AnyChange['kind']): boolean {
+	if (kind === 'execute') return true
+	const method = `apply${kind.charAt(0).toUpperCase()}${kind.slice(1)}` as keyof OrmAdapter
+	return typeof (adapter as any)[method] === 'function'
+}
+
+function fieldsEqual(target: SchemaFieldInfo, discovered: DiscoveredField): boolean {
+	if (target.type !== discovered.type) return false
+	if ((target.nullable ?? false) !== discovered.nullable) return false
+	if (target.default !== discovered.default) return false
+	if ((target.unique ?? false) !== (discovered.unique ?? false)) return false
+	return true
 }
 
 function extractSchemaInfo(schema: AnySchema): {
@@ -62,16 +59,13 @@ function extractSchemaInfo(schema: AnySchema): {
 	return { name: schema.name, pk: { name: pkField.name, type: pkType }, fields }
 }
 
+const KNOWN_FIELD_TYPES: ReadonlySet<string> = new Set<FieldTypeName>(['string', 'number', 'boolean', 'array', 'object', 'date'])
+
 function inferFieldType(pipe: any): FieldTypeName {
 	if (!pipe) return 'string'
 	const schema = typeof pipe.schema === 'function' ? pipe.schema() : undefined
 	if (schema?.type) {
-		if (schema.type === 'string') return 'string'
-		if (schema.type === 'number') return 'number'
-		if (schema.type === 'boolean') return 'boolean'
-		if (schema.type === 'array') return 'array'
-		if (schema.type === 'object') return 'object'
-		if (schema.type === 'date') return 'date'
+		if (KNOWN_FIELD_TYPES.has(schema.type)) return schema.type as FieldTypeName
 		return 'string'
 	}
 	const std = pipe['~standard']
@@ -146,7 +140,6 @@ export function diffSchemas(
 				changes.push({ kind: 'modifyField', table: info.name, name: tField.name, to: { name: tField.name, type: tField.type, ...(tField.nullable ? { nullable: true } : {}) } })
 			}
 		}
-
 	}
 
 	return changes

--- a/src/orm/migrations/index.ts
+++ b/src/orm/migrations/index.ts
@@ -1,3 +1,6 @@
+export * from './codegen'
+export * from './diff'
+export * from './introspection-types'
 export * from './migrator'
 export * from './pending'
 export * from './types'

--- a/src/orm/migrations/introspection-types.ts
+++ b/src/orm/migrations/introspection-types.ts
@@ -1,0 +1,31 @@
+import type { FieldTypeName } from '../adapter'
+
+export type DiscoveredField = {
+	name: string
+	type: FieldTypeName
+	nullable: boolean
+	default?: string | number | boolean | null
+	unique?: boolean
+}
+
+export type DiscoveredIndex = {
+	name: string
+	on: ReadonlyArray<string>
+	unique: boolean
+}
+
+export type DiscoveredForeignKey = {
+	name: string
+	on: string
+	references: { table: string; column: string }
+	onDelete?: 'cascade' | 'restrict' | 'setNull' | 'noAction'
+	onUpdate?: 'cascade' | 'restrict' | 'setNull' | 'noAction'
+}
+
+export type DiscoveredSchema = {
+	name: string
+	pk?: { name: string; type: FieldTypeName }
+	fields: ReadonlyArray<DiscoveredField>
+	indexes: ReadonlyArray<DiscoveredIndex>
+	foreignKeys: ReadonlyArray<DiscoveredForeignKey>
+}

--- a/src/orm/orm-adapter.ts
+++ b/src/orm/orm-adapter.ts
@@ -5,6 +5,7 @@ import { Instance, type ClassRef } from '../instance'
 import type { AggregateOpName, FieldTypeName, FilterOpName, UpdateOpName } from './adapter'
 import type { OrmUse } from './adapters/base'
 import { FilterGroup } from './filter'
+import type { DiscoveredSchema } from './migrations/introspection-types'
 import type { AddFieldChange, AddForeignKeyChange, AddIndexChange, CreateTableChange, DropFieldChange, DropForeignKeyChange, DropIndexChange, DropTableChange, ModifyFieldChange, RenameFieldChange, RenameTableChange } from './migrations/types'
 import type { QueryOptions } from './query-options'
 import type { AnySchema } from './schema'
@@ -63,6 +64,7 @@ export abstract class OrmAdapter {
 	applyDropIndex?(change: DropIndexChange): Promise<void>
 	applyAddForeignKey?(change: AddForeignKeyChange): Promise<void>
 	applyDropForeignKey?(change: DropForeignKeyChange): Promise<void>
+	introspect?(): Promise<DiscoveredSchema[]>
 
 	protected onFatalError(err: unknown): never {
 		const wrapped = err instanceof EquippedError ? err : new EquippedError('OrmAdapter fatal error', {}, err)


### PR DESCRIPTION
Automated implementation by Sandcastle for issue #108.

Closes #108

_Awaiting human review and approval. This PR targets the long-lived feature branch `feature/orm`._